### PR TITLE
Adds filter for other bordereaux than bsdd

### DIFF
--- a/src/sheets/queries.py
+++ b/src/sheets/queries.py
@@ -71,6 +71,7 @@ where
     and is_deleted = false
     and created_at >= current_date - interval '1 year'
     and status::text not in ('DRAFT', 'INITIAL', 'SIGNED_BY_WORKER')
+    and not is_draft
 order by
     created_at asc"""
 
@@ -98,6 +99,7 @@ where
     and is_deleted = false
     and created_at >= current_date - interval '1 year'
     and status::text not in ('DRAFT', 'INITIAL', 'SIGNED_BY_WORKER')
+    and not is_draft
 order by
     created_at asc"""
 
@@ -124,6 +126,7 @@ where
     and is_deleted = false
     and created_at >= current_date - interval '1 year'
     and status::text not in ('DRAFT', 'INITIAL', 'SIGNED_BY_WORKER')
+    and not is_draft
 order by
     created_at asc"""
 
@@ -150,6 +153,7 @@ where
     and is_deleted = false
     and created_at >= current_date - interval '1 year'
     and  status::text not in ('DRAFT', 'INITIAL', 'SIGNED_BY_WORKER')
+    and not is_draft
 order by
     created_at asc
 """


### PR DESCRIPTION
Les brouillons sont filtrés pour les BSDD en se basant sur la valeur de `status`. J'ai rajouté un filtre pour les autres bordereaux qui utilise la valeur de `is_draft`.

- [ ] Mettre à jour le change log
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/37a331c647a38a191b2a1207?card=tra-11633)
