### PR TITLE
Adds more precision for stock numbers

### DIFF
--- a/src/sheets/graph_processors/html_components_processors.py
+++ b/src/sheets/graph_processors/html_components_processors.py
@@ -305,8 +305,8 @@ class StorageStatsProcessor:
         stock_by_waste_code.sort_values(ascending=False, inplace=True)
 
         stock_by_waste_code = stock_by_waste_code[stock_by_waste_code > 0]
-        total_stock = format_number_str(stock_by_waste_code.sum(), precision=0)
-        stock_by_waste_code = stock_by_waste_code.apply(format_number_str, precision=0)
+        total_stock = format_number_str(stock_by_waste_code.sum(), precision=1)
+        stock_by_waste_code = stock_by_waste_code.apply(format_number_str, precision=1)
         stock_by_waste_code = pd.merge(
             stock_by_waste_code,
             self.waste_codes_df,


### PR DESCRIPTION
Je propose de passer à un chiffre après la virgule pour éviter les arrondis qui peuvent induire en erreur.
Avant :
![image](https://user-images.githubusercontent.com/30115537/232796736-a9a8f433-d7d0-44f3-9cbb-02a11dc88d95.png)
Après :
![image](https://user-images.githubusercontent.com/30115537/232796810-118a2e04-7674-40ca-8fc7-9406276c6e62.png)

- [ ] Mettre à jour le change log
---

- [Ticket Favro]()
