### PR TITLE
Adds first implementation of mean processing time

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,9 @@ Les changements importants de Trackdéchets préparation inspection sont documen
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
 
+## 16/05/2023
+- Ajout du temps de traitement moyen pour les bordereaux qui ont un traitement d'une durée supérieure à un mois.
+
 ## 11/05/2023
 - Ajout d'un formulaire d'enquête.
 
@@ -14,19 +17,15 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 
 ## 03/05/2023
-
 - Ajout de filtre de dates sur tous les data processors pour être sûr que les données soient 
 comprises dans une fenêtre d'une année glissante.
 
 ## 20/04/2023
-
 - Ajout d'un composant listant les bordereaux annulés.
 
 ## 03/04/2023
-
 - Ajoute un composant permettant de lister les déchets indiqués comme dangereux mais qui n'ont pas de code déchets dangereux
 
 ## 30/03/2023
-
 - Corrige la gestion des date manquantes sur le tableau icpe [#3](https://github.com/MTES-MCT/trackdechets-preparation-inspection/pull/3)
 - Améliore le composant de statistiques déchets [#4](https://github.com/MTES-MCT/trackdechets-preparation-inspection/pull/4)

--- a/src/templates/sheets/components/stats_graph.html
+++ b/src/templates/sheets/components/stats_graph.html
@@ -159,12 +159,15 @@
             <td>{{ received_bs_stats.archived }}</td>
           </tr>
           <tr>
-            <th scope="row">Traitements > 1 mois</th>
+            <th colspan="3">Traitement > 1 mois</th>
+          </tr>
+          <tr>
+            <th scope="row">Nombre</th>
             <td>{{ emitted_bs_stats.processed_in_more_than_one_month_count }}</td>
             <td>{{ received_bs_stats.processed_in_more_than_one_month_count }}</td>
           </tr>
           <tr>
-            <th scope="row">Temps moyen de traitement (pour les traitements > 1 mois)</th>
+            <th scope="row">Temps moyen de traitement</th>
             <td>
               {% if emitted_bs_stats.processed_in_more_than_one_month_avg_processing_time %}
                 {{ emitted_bs_stats.processed_in_more_than_one_month_avg_processing_time }}

--- a/src/templates/sheets/components/stats_graph.html
+++ b/src/templates/sheets/components/stats_graph.html
@@ -111,6 +111,7 @@
 
   th[scope='row'] {
     text-align: left;
+    width: 50%;
   }
 
   th[scope='col'] {
@@ -136,68 +137,85 @@
 
 </style>
 {% if emitted_bs_stats.total != 0 or received_bs_stats.total != "0" %}
-    <div class="col-framed col-print">
-        <div class="bs-stats">
-            <table>
-                <thead>
-                    <tr>
-                        <th scope="col" class="table-headline">Bordereaux</th>
-                        <th scope="col">Émis</th>
-                        <th scope="col">Reçus</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <th scope="row">Total</th>
-                        <td>{{ emitted_bs_stats.total }}</td>
-                        <td>{{ received_bs_stats.total }}</td>
-                    </tr>
-                    <tr>
-                        <th scope="row">Archivés</th>
-                        <td>{{ emitted_bs_stats.archived }}</td>
-                        <td>{{ received_bs_stats.archived }}</td>
-                    </tr>
-                    <tr>
-                        <th scope="row">Traitements > 1 mois</th>
-                        <td>{{ emitted_bs_stats.more_than_one_month }}</td>
-                        <td>{{ received_bs_stats.more_than_one_month }}</td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
-        <div class="revised-bs-count">
-            <span class="td-font-lead">{{ revised_bs_count }}</span>bordereaux corrigés
-        </div>
-        <div>
-            <p class="sc-number">
-                <span class="td-font-display">{{ total_incoming_weight }}</span>tonnes
-                entrantes
-            </p>
-        </div>
-        <div>
-            <svg style="width:100%;height:45px;">
-                <rect width="{{ incoming_bar_size }}%" height="20" y="0" x="0"
-                fill="rgba(255, 0, 15, 0.7)">
-                </rect>
-                <rect width="100%" height="20" y="0" x="0"
-                stroke="rgba(255, 0, 15, 1)", fill="rgba(0,0,0,0)">
-                </rect>
-                <rect width="{{ outgoing_bar_size }}%" height="20" y="25" x="0"
-                fill="rgba(106, 106, 244, 0.7)">
-                </rect>
-                <rect width="100%" height="20" y="25" x="0"
-                stroke="rgba(106, 106, 244, 1)", fill="rgba(0,0,0,0)">
-                </rect>
-            </svg>
-        </div>
-        <div>
-            <p class="sc-number">
-                <span class="td-font-display">{{ total_outgoing_weight }}</span>tonnes sortantes
-            </p>
-        </div>
+  <div class="col-framed col-print">
+    <div class="bs-stats">
+      <table>
+        <thead>
+          <tr>
+            <th scope="col" class="table-headline">Bordereaux</th>
+            <th scope="col">Émis</th>
+            <th scope="col">Reçus</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">Total</th>
+            <td>{{ emitted_bs_stats.total }}</td>
+            <td>{{ received_bs_stats.total }}</td>
+          </tr>
+          <tr>
+            <th scope="row">Archivés</th>
+            <td>{{ emitted_bs_stats.archived }}</td>
+            <td>{{ received_bs_stats.archived }}</td>
+          </tr>
+          <tr>
+            <th scope="row">Traitements > 1 mois</th>
+            <td>{{ emitted_bs_stats.processed_in_more_than_one_month_count }}</td>
+            <td>{{ received_bs_stats.processed_in_more_than_one_month_count }}</td>
+          </tr>
+          <tr>
+            <th scope="row">Temps moyen de traitement (pour les traitements > 1 mois)</th>
+            <td>
+              {% if emitted_bs_stats.processed_in_more_than_one_month_avg_processing_time %}
+                {{ emitted_bs_stats.processed_in_more_than_one_month_avg_processing_time }}
+              {% else %}
+                N/A
+              {% endif %}
+            </td>
+            <td>
+              {% if received_bs_stats.processed_in_more_than_one_month_avg_processing_time %}
+                {{ received_bs_stats.processed_in_more_than_one_month_avg_processing_time }}
+              {% else %}
+                N/A
+              {% endif %}
+            </td>
+          </tr>
+        </tbody>
+      </table>
     </div>
+    <div class="revised-bs-count">
+      <span class="td-font-lead">{{ revised_bs_count }}</span>bordereaux corrigés
+    </div>
+    <div>
+      <p class="sc-number">
+        <span class="td-font-display">{{ total_incoming_weight }}</span>tonnes
+        entrantes
+      </p>
+    </div>
+    <div>
+      <svg style="width:100%;height:45px;">
+        <rect width="{{ incoming_bar_size }}%" height="20" y="0" x="0"
+        fill="rgba(255, 0, 15, 0.7)">
+        </rect>
+        <rect width="100%" height="20" y="0" x="0"
+        stroke="rgba(255, 0, 15, 1)", fill="rgba(0,0,0,0)">
+        </rect>
+        <rect width="{{ outgoing_bar_size }}%" height="20" y="25" x="0"
+        fill="rgba(106, 106, 244, 0.7)">
+        </rect>
+        <rect width="100%" height="20" y="25" x="0"
+        stroke="rgba(106, 106, 244, 1)", fill="rgba(0,0,0,0)">
+        </rect>
+      </svg>
+    </div>
+    <div>
+      <p class="sc-number">
+        <span class="td-font-display">{{ total_outgoing_weight }}</span>tonnes sortantes
+      </p>
+    </div>
+  </div>
 {% else %}
-    <div class="sc-primary">
-        <span>Pas de données</span>
-    </div>
+  <div class="sc-primary">
+    <span>Pas de données</span>
+  </div>
 {% endif %}


### PR DESCRIPTION
Ajoute le temps de traitement moyen (en nombre de jours) pour les bordereaux dont le traitement a duré plus d'un mois.

Exemple :
![image](https://github.com/MTES-MCT/trackdechets-preparation-inspection/assets/30115537/245c2fca-0b31-44d5-9196-1454c41601f9)


- [ ] Mettre à jour le change log
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/37a331c647a38a191b2a1207?card=tra-11747)
