### PR TITLE
Tra-11827/fix-traceability-breaks-pdf

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,9 @@ Les changements importants de Trackdéchets préparation inspection sont documen
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
 
+## 25/05/2023
+- Corrige le problème de certains tableaux qui étaient coupés en version PDF.
+
 ## 17/05/2023
 - Ajout des statistiques sur les déchets non dangereux suivis par BSDD.
 

--- a/src/sheets/templatetags/graph_tags.py
+++ b/src/sheets/templatetags/graph_tags.py
@@ -52,16 +52,18 @@ def render_icpe(computed):
 
 
 @register.inclusion_tag("sheets/components/traceabilty_break.html")
-def render_traceabilty_break(computed):
+def render_traceabilty_break(computed, graph_context="web"):
     return {
         "traceability_interruptions_data": computed.traceability_interruptions_data,
+        "graph_context": graph_context,
     }
 
 
 @register.inclusion_tag("sheets/components/waste_is_dangerous_statements.html")
-def render_waste_is_dangerous_statements(computed):
+def render_waste_is_dangerous_statements(computed, graph_context="web"):
     return {
         "waste_is_dangerous_statements_data": computed.waste_is_dangerous_statements_data,
+        "graph_context": graph_context,
     }
 
 

--- a/src/templates/sheets/components/traceabilty_break.html
+++ b/src/templates/sheets/components/traceabilty_break.html
@@ -4,8 +4,8 @@
         L'établissement a indiqué sur les BSDs être autorisé à la rupture de traçabilité, par arrêté préfectoral pour
         les déchets suivants:
     </p>
-    <div class="fr-table">
-        <table>
+    <div{% if graph_context == "web" %}class="fr-table "{% endif %}>
+        <table {% if graph_context == "web" %}{% else %}class="pdf-table"{% endif %}>
             <tbody>
                 {% for row in traceability_interruptions_data %}
                     <tr>

--- a/src/templates/sheets/components/waste_is_dangerous_statements.html
+++ b/src/templates/sheets/components/waste_is_dangerous_statements.html
@@ -1,8 +1,8 @@
 <h3 class="cell__title">Déclaration de déchets dangereux avec code déchet non dangereux</h3>
 {% if waste_is_dangerous_statements_data %}
     <p>L'établissement a déclaré des déchets comme étant dangereux pour les codes déchets non dangereux suivants :</p>
-    <div class="fr-table">
-        <table>
+    <div {% if graph_context == "web" %}class="fr-table "{% endif %}>
+        <table {% if graph_context == "web" %}{% else %}class="pdf-table"{% endif %}>
             <thead>
                 <tr>
                     <th scope="col">Code déchet</th>

--- a/src/templates/sheets/sheetpdf.html
+++ b/src/templates/sheets/sheetpdf.html
@@ -183,8 +183,8 @@
             {#  end bsvhu #}
             {#  "waste is dangerous" statements #}
             {% if sheet.waste_is_dangerous_statements_data %}
-                <div class="cell cell--bordered cell--half">
-                    {% render_waste_is_dangerous_statements sheet %}
+                <div>
+                    {% render_waste_is_dangerous_statements sheet graph_context="pdf" %}
                 </div>
             {% endif %}
             {# end "waste is dangerous" statements #}
@@ -238,13 +238,10 @@
                     {# end ICPE #}
                 </div>
             </div>
-            <div class="row">
+            <div>
                 {# traceability #}
-                <div class="cell cell--bordered">
-                    {% render_traceabilty_break sheet %}
-                </div>
+                {% render_traceabilty_break sheet graph_context="pdf" %}
                 {# end traceability #}
-                {# input/output #}
             </div>
             {# bsd canceled table #}
             <div>
@@ -258,6 +255,7 @@
             {# end ame emitter recipient table #}
         </section>
         <section class="vertical">
+            {# input/output #}
             <div>
                 <h3 class="section__title">
                     Liste des déchets entrants/sortants


### PR DESCRIPTION
Cette PR corrige le problème de certains tableaux qui étaient coupés en version PDF car ils n'avaient pas la bonne classe CSS.

- [x] Mettre à jour le change log
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/37a331c647a38a191b2a1207?card=tra-11827)
