### PR TITLE
Adds packaging data to BSFF stats

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,9 @@ Les changements importants de Trackdéchets préparation inspection sont documen
 
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
+
+## 07/06/2023
+- Ajout des données de contenants pour les BSFF.
 ## 30/05/2023
 - Ajout d'une table listant les bordereaux présentant des quantités aberrantes.
 ## 29/05/2023

--- a/src/sheets/data_processing.py
+++ b/src/sheets/data_processing.py
@@ -171,7 +171,7 @@ class SheetProcessor:
                 self.siret,
                 df,
                 variable_name="quantity_received" if bsd_type != BSDASRI else "volume",
-                packagings_data=self.bsff_packagings_df,
+                packagings_data=self.bsff_packagings_df if bsd_type == BSFF else None,
             )
             stock_graph_data = stock_graph.build()
             if stock_graph_data:
@@ -185,7 +185,7 @@ class SheetProcessor:
                 if bsd_type != BSDASRI
                 else "volume",
                 bs_revised_data=self.revised_bsds_dfs.get(bsd_type, None),
-                packagings_data=self.bsff_packagings_df,
+                packagings_data=self.bsff_packagings_df if bsd_type == BSFF else None,
             )
             stats_graph_data = stats_graph.build()
             if stats_graph_data:

--- a/src/sheets/database.py
+++ b/src/sheets/database.py
@@ -10,6 +10,7 @@ from .queries import (
     sql_bsdasri_query_str,
     sql_bsdd_non_dangerous_query_str,
     sql_bsdd_query_str,
+    sql_bsff_packagings_query_str,
     sql_bsff_query_str,
     sql_bsvhu_query_str,
     sql_company_query_str,
@@ -125,6 +126,14 @@ def build_bsff_query(siret):
         sql_bsff_query_str,
         query_params={"siret": siret},
         date_columns=bsd_date_params,
+    )
+
+
+def build_bsff_packagings_query(siret):
+    return build_query(
+        sql_bsff_packagings_query_str,
+        query_params={"siret": siret},
+        date_columns=["operation_date", "acceptation_date"],
     )
 
 

--- a/src/sheets/graph_processors/html_components_processors.py
+++ b/src/sheets/graph_processors/html_components_processors.py
@@ -60,6 +60,7 @@ class BsdStatsProcessor:
                 [
                     "total_packagings",
                     "processed_in_more_than_one_month_packagings_count",
+                    "processed_in_more_than_one_month_packagings_avg_processing_time",
                 ]
             )
 
@@ -170,7 +171,7 @@ class BsdStatsProcessor:
                     right_on="bsff_id",
                     validate="one_to_many",
                 )
-                target["processed_in_more_than_one_month_packagings_count"] = len(
+                bs_data_with_packagings_processed_in_more_than_one_month = (
                     bs_data_with_packagings[
                         (
                             bs_data_with_packagings["operation_date"]
@@ -179,6 +180,23 @@ class BsdStatsProcessor:
                         > np.timedelta64(1, "M")
                     ]
                 )
+                target["processed_in_more_than_one_month_packagings_count"] = len(
+                    bs_data_with_packagings_processed_in_more_than_one_month
+                )
+
+                res = (
+                    (
+                        bs_data_with_packagings_processed_in_more_than_one_month[
+                            "operation_date"
+                        ]
+                        - bs_data_with_packagings_processed_in_more_than_one_month[
+                            "received_at"
+                        ]
+                    ).mean()
+                ).total_seconds() / (24 * 3600)
+                target[
+                    "processed_in_more_than_one_month_packagings_avg_processing_time"
+                ] = f"{res:.1f}j"
 
         bs_revised_data = self.bs_revised_data
         if bs_revised_data is not None:

--- a/src/sheets/graph_processors/plotly_components_processors.py
+++ b/src/sheets/graph_processors/plotly_components_processors.py
@@ -24,15 +24,26 @@ class BsdQuantitiesGraph:
         DataFrame containing data for a given 'bordereau' type.
     variable_name: str
         The name of the variable to use to compute quantity statistics.
+    packagings_data : DataFrame
+        For BSFF data, packagings dataset to be able to compute the quantities.
     """
 
-    def __init__(self, company_siret, bs_data, variable_name="quantity_received"):
+    def __init__(
+        self,
+        company_siret: str,
+        bs_data: pd.DataFrame,
+        variable_name: str = "quantity_received",
+        packagings_data: pd.DataFrame = None,
+    ):
         self.bs_data = bs_data
+        self.packagings_data = packagings_data
         self.company_siret = company_siret
         self.variable_name = variable_name
 
         self.incoming_data_by_month = None
         self.outgoing_data_by_month = None
+
+        self.figure = None
 
     def _preprocess_data(self) -> None:
         bs_data = self.bs_data
@@ -52,21 +63,44 @@ class BsdQuantitiesGraph:
             & (bs_data["sent_at"] <= today_date)
         ]
 
-        self.incoming_data_by_month = (
+        incoming_data_by_month = (
             incoming_data.groupby(pd.Grouper(key="received_at", freq="1M"))[
                 self.variable_name
             ]
             .sum()
             .replace(0, np.nan)
         )
-
-        self.outgoing_data_by_month = (
+        outgoing_data_by_month = (
             outgoing_data.groupby(pd.Grouper(key="sent_at", freq="1M"))[
                 self.variable_name
             ]
             .sum()
             .replace(0, np.nan)
         )
+
+        if self.packagings_data is not None:
+            incoming_data_by_month = (
+                incoming_data.merge(
+                    self.packagings_data, left_on="id", right_on="bsff_id"
+                )
+                .groupby(pd.Grouper(key="acceptation_date", freq="1M"))[
+                    "acceptation_weight"
+                ]
+                .sum()
+                .replace(0, np.nan)
+            )
+            outgoing_data_by_month = (
+                outgoing_data.merge(
+                    self.packagings_data, left_on="id", right_on="bsff_id"
+                )
+                .groupby(pd.Grouper(key="sent_at", freq="1M"))["acceptation_weight"]
+                .sum()
+                .replace(0, np.nan)
+            )
+
+        self.incoming_data_by_month = incoming_data_by_month
+
+        self.outgoing_data_by_month = outgoing_data_by_month
 
     def _check_data_empty(self) -> bool:
         incoming_data_by_month = self.incoming_data_by_month
@@ -146,7 +180,7 @@ class BsdQuantitiesGraph:
             )
 
         dtick = "M2"
-        if max(len(incoming_data_by_month), len(outgoing_data_by_month)) < 3:
+        if max(len(incoming_data_by_month), len(outgoing_data_by_month)) <= 3:
             dtick = "M1"
 
         fig.update_xaxes(
@@ -277,9 +311,14 @@ class BsdTrackedAndRevisedProcessor:
             marker_color="#E1000F",
         )
 
-        tick0_min = min(
-            bs_emitted_by_month.index.min(), bs_received_by_month.index.min()
-        )
+        if pd.isna(bs_emitted_by_month.index.min()):
+            tick0_min = bs_received_by_month.index.min()
+        elif pd.isna(bs_received_by_month.index.min()):
+            tick0_min = bs_emitted_by_month.index.min()
+        else:
+            tick0_min = min(
+                bs_emitted_by_month.index.min(), bs_received_by_month.index.min()
+            )
 
         max_y = max(bs_emitted_by_month.max(), bs_received_by_month.max())
 
@@ -317,16 +356,15 @@ class BsdTrackedAndRevisedProcessor:
         )
 
         ticklabelstep = 2
-        if max_points < 3:
+        if max_points <= 3:
             ticklabelstep = 1
 
         fig.update_xaxes(
-            dtick="M1",
+            dtick=f"M{ticklabelstep}",
             tickangle=0,
             tickformat="%b",
             tick0=tick0_min,
             ticks="outside",
-            ticklabelstep=ticklabelstep,
             gridcolor="#ccc",
         )
 

--- a/src/sheets/queries.py
+++ b/src/sheets/queries.py
@@ -179,6 +179,35 @@ where
 order by
     created_at asc"""
 
+sql_bsff_packagings_query_str = """
+select
+    id,
+    bsff_id,
+    acceptation_date,
+    operation_date,
+    volume,
+    acceptation_weight,
+    weight
+from
+    trusted_zone_trackdechets.bsff_packaging bp
+where
+    bp.bsff_id in (
+    select
+        id
+    from
+        trusted_zone_trackdechets.bsff
+    where
+        (emitter_company_siret = :siret
+            or destination_company_siret = :siret)
+        and is_deleted = false
+        and created_at >= current_date - interval '1 year'
+        and status::text not in ('DRAFT', 'INITIAL')
+            and not is_draft
+        order by
+            created_at asc
+)
+"""
+
 sql_bsvhu_query_str = """
 select
     id,

--- a/src/templates/sheets/components/stats_graph.html
+++ b/src/templates/sheets/components/stats_graph.html
@@ -137,97 +137,111 @@
 
 </style>
 {% if emitted_bs_stats.total != 0 or received_bs_stats.total != "0" %}
-    <div class="col-framed col-print">
-        <div class="bs-stats">
-            <table>
-                <thead>
-                    <tr>
-                        <th scope="col" class="table-headline">Bordereaux</th>
-                        <th scope="col">Émis</th>
-                        <th scope="col">Reçus</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <th scope="row">Total</th>
-                        <td>{{ emitted_bs_stats.total }}</td>
-                        <td>{{ received_bs_stats.total }}</td>
-                    </tr>
-                    <tr>
-                        <th scope="row">Archivés</th>
-                        <td>{{ emitted_bs_stats.archived }}</td>
-                        <td>{{ received_bs_stats.archived }}</td>
-                    </tr>
-                    <tr>
-                        <th colspan="3">Traitement > 1 mois</th>
-                    </tr>
-                    <tr>
-                        <th scope="row">Nombre</th>
-                        <td>{{ emitted_bs_stats.processed_in_more_than_one_month_count }}</td>
-                        <td>{{ received_bs_stats.processed_in_more_than_one_month_count }}</td>
-                    </tr>
-                    <tr>
-                        <th scope="row">Temps moyen de traitement</th>
-                        <td>
-                            {% if emitted_bs_stats.processed_in_more_than_one_month_avg_processing_time %}
-                                {{ emitted_bs_stats.processed_in_more_than_one_month_avg_processing_time }}
-                            {% else %}
-                                N/A
-                            {% endif %}
-                        </td>
-                        <td>
-                            {% if received_bs_stats.processed_in_more_than_one_month_avg_processing_time %}
-                                {{ received_bs_stats.processed_in_more_than_one_month_avg_processing_time }}
-                            {% else %}
-                                N/A
-                            {% endif %}
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
-        <div class="revised-bs-count">
-            <span class="td-font-lead">{{ revised_bs_count }}</span>bordereaux corrigés
-        </div>
-        <div>
-            <p class="sc-number">
-                <span class="td-font-display">{{ total_incoming_quantity }}</span>
-                {% if bsd_type == "bsdasri" %}
-                    m³ entrants
-                {% else %}
-                    tonnes entrantes
-                {% endif %}
-            </p>
-        </div>
-        <div>
-            <svg style="width:100%;height:45px;">
-                <rect width="{{ incoming_bar_size }}%" height="20" y="0" x="0"
-                fill="rgba(255, 0, 15, 0.7)">
-                </rect>
-                <rect width="100%" height="20" y="0" x="0"
-                stroke="rgba(255, 0, 15, 1)", fill="rgba(0,0,0,0)">
-                </rect>
-                <rect width="{{ outgoing_bar_size }}%" height="20" y="25" x="0"
-                fill="rgba(106, 106, 244, 0.7)">
-                </rect>
-                <rect width="100%" height="20" y="25" x="0"
-                stroke="rgba(106, 106, 244, 1)", fill="rgba(0,0,0,0)">
-                </rect>
-            </svg>
-        </div>
-        <div>
-            <p class="sc-number">
-                <span class="td-font-display">{{ total_outgoing_quantity }}</span>
-                {% if bsd_type == "bsdasri" %}
-                    m³ sortants
-                {% else %}
-                    tonnes sortantes
-                {% endif %}
-            </p>
-        </div>
+  <div class="col-framed col-print">
+    <div class="bs-stats">
+      <table>
+        <thead>
+          <tr>
+            <th scope="col" class="table-headline">Bordereaux</th>
+            <th scope="col">Émis</th>
+            <th scope="col">Reçus</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">Total</th>
+            <td>{{ emitted_bs_stats.total }}</td>
+            <td>{{ received_bs_stats.total }}</td>
+          </tr>
+          <tr>
+            <th scope="row">Archivés</th>
+            <td>{{ emitted_bs_stats.archived }}</td>
+            <td>{{ received_bs_stats.archived }}</td>
+          </tr>
+          {% if bsd_type == "bsff" %}
+            <tr>
+              <th scope="row">Nombre de contenants</th>
+              <td>{{ emitted_bs_stats.total_packagings }}</td>
+              <td>{{ received_bs_stats.total_packagings }}</td>
+            </tr>
+          {% endif %}
+          <tr>
+            <th colspan="3">Traitement > 1 mois</th>
+          </tr>
+          <tr>
+            <th scope="row">Nombre</th>
+            <td>{{ emitted_bs_stats.processed_in_more_than_one_month_count }}</td>
+            <td>{{ received_bs_stats.processed_in_more_than_one_month_count }}</td>
+          </tr>
+          {% if bsd_type == "bsff" %}
+            <tr>
+              <th scope="row">Nombre de contenants</th>
+              <td>{{ emitted_bs_stats.processed_in_more_than_one_month_packagings_count }}</td>
+              <td>{{ received_bs_stats.processed_in_more_than_one_month_packagings_count }}</td>
+            </tr>
+          {% endif %}
+          <tr>
+            <th scope="row">Temps moyen de traitement</th>
+            <td>
+              {% if emitted_bs_stats.processed_in_more_than_one_month_avg_processing_time %}
+                {{ emitted_bs_stats.processed_in_more_than_one_month_avg_processing_time }}
+              {% else %}
+                N/A
+              {% endif %}
+            </td>
+            <td>
+              {% if received_bs_stats.processed_in_more_than_one_month_avg_processing_time %}
+                {{ received_bs_stats.processed_in_more_than_one_month_avg_processing_time }}
+              {% else %}
+                N/A
+              {% endif %}
+            </td>
+          </tr>
+        </tbody>
+      </table>
     </div>
+    <div class="revised-bs-count">
+      <span class="td-font-lead">{{ revised_bs_count }}</span>bordereaux corrigés
+    </div>
+    <div>
+      <p class="sc-number">
+        <span class="td-font-display">{{ total_incoming_quantity }}</span>
+        {% if bsd_type == "bsdasri" %}
+          m³ entrants
+        {% else %}
+          tonnes entrantes
+        {% endif %}
+      </p>
+    </div>
+    <div>
+      <svg style="width:100%;height:45px;">
+        <rect width="{{ incoming_bar_size }}%" height="20" y="0" x="0"
+        fill="rgba(255, 0, 15, 0.7)">
+        </rect>
+        <rect width="100%" height="20" y="0" x="0"
+        stroke="rgba(255, 0, 15, 1)", fill="rgba(0,0,0,0)">
+        </rect>
+        <rect width="{{ outgoing_bar_size }}%" height="20" y="25" x="0"
+        fill="rgba(106, 106, 244, 0.7)">
+        </rect>
+        <rect width="100%" height="20" y="25" x="0"
+        stroke="rgba(106, 106, 244, 1)", fill="rgba(0,0,0,0)">
+        </rect>
+      </svg>
+    </div>
+    <div>
+      <p class="sc-number">
+        <span class="td-font-display">{{ total_outgoing_quantity }}</span>
+        {% if bsd_type == "bsdasri" %}
+          m³ sortants
+        {% else %}
+          tonnes sortantes
+        {% endif %}
+      </p>
+    </div>
+  </div>
 {% else %}
-    <div class="sc-primary">
-        <span>Pas de données</span>
-    </div>
+  <div class="sc-primary">
+    <span>Pas de données</span>
+  </div>
 {% endif %}

--- a/src/templates/sheets/components/stats_graph.html
+++ b/src/templates/sheets/components/stats_graph.html
@@ -173,13 +173,6 @@
             <td>{{ emitted_bs_stats.processed_in_more_than_one_month_count }}</td>
             <td>{{ received_bs_stats.processed_in_more_than_one_month_count }}</td>
           </tr>
-          {% if bsd_type == "bsff" %}
-            <tr>
-              <th scope="row">Nombre de contenants</th>
-              <td>{{ emitted_bs_stats.processed_in_more_than_one_month_packagings_count }}</td>
-              <td>{{ received_bs_stats.processed_in_more_than_one_month_packagings_count }}</td>
-            </tr>
-          {% endif %}
           <tr>
             <th scope="row">Temps moyen de traitement</th>
             <td>
@@ -197,6 +190,30 @@
               {% endif %}
             </td>
           </tr>
+          {% if bsd_type == "bsff" %}
+            <tr>
+              <th scope="row">Nombre de contenants</th>
+              <td>{{ emitted_bs_stats.processed_in_more_than_one_month_packagings_count }}</td>
+              <td>{{ received_bs_stats.processed_in_more_than_one_month_packagings_count }}</td>
+            </tr>
+            <tr>
+              <th scope="row">Temps moyen de traitement - contenants</th>
+              <td>
+                {% if emitted_bs_stats.processed_in_more_than_one_month_packagings_avg_processing_time %}
+                  {{ emitted_bs_stats.processed_in_more_than_one_month_packagings_avg_processing_time }}
+                {% else %}
+                  N/A
+                {% endif %}
+              </td>
+              <td>
+                {% if received_bs_stats.processed_in_more_than_one_month_packagings_avg_processing_time %}
+                  {{ received_bs_stats.processed_in_more_than_one_month_packagings_avg_processing_time }}
+                {% else %}
+                  N/A
+                {% endif %}
+              </td>
+            </tr>
+          {% endif %}
         </tbody>
       </table>
     </div>


### PR DESCRIPTION
Cette PR ajoute une granularité "contenant" aux statistiques BSFF. Ainsi, pour le BSFF, les quantités entrantes/sortantes sont calculées à partir des données des contenants liés aux bordereaux. De même l'on calcule deux nouvelles statistiques dans le composant des données sur l'année.

Exemple :

<img width="1277" alt="image" src="https://github.com/MTES-MCT/trackdechets-preparation-inspection/assets/30115537/778a37e0-c63b-4387-b5aa-a2e3826742d7">


- [ ] Mettre à jour le change log
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/37a331c647a38a191b2a1207?card=tra-11325)
