### PR TITLE
Handles NaN in waste description

### DIFF
--- a/src/sheets/graph_processors/html_components_processors.py
+++ b/src/sheets/graph_processors/html_components_processors.py
@@ -436,6 +436,7 @@ class InputOutputWasteTableProcessor:
             final_df["quantity_received"] = final_df["quantity_received"].apply(
                 lambda x: format_number_str(x, 2)
             )
+            final_df["description"] = final_df["description"].fillna("")
             self.preprocessed_df = final_df[
                 [
                     "waste_code",


### PR DESCRIPTION
Si les codes déchets ne sont pas rentrés au bon format sur les bordereaux, la description associée au code déchet n'est pas retrouvée et donc on se retrouve avec un "NaN" non serializable. Ce hotfix remplace les NaN par des chaînes vides.

