### PR TITLE
Fixes received_at being NA for quantity outliers

### DIFF
--- a/src/sheets/graph_processors/html_components_processors.py
+++ b/src/sheets/graph_processors/html_components_processors.py
@@ -1431,7 +1431,7 @@ class QuantityOutliersTableProcessor:
                 "sent_at": e.sent_at.strftime("%d/%m/%Y %H:%M")
                 if not pd.isna(e.sent_at)
                 else None,
-                "received_at  ": e.received_at.strftime("%d/%m/%Y %H:%M")
+                "received_at": e.received_at.strftime("%d/%m/%Y %H:%M")
                 if not pd.isna(e.received_at)
                 else None,
             }


### PR DESCRIPTION
Une typo empêchait l'affichage des dates de réception dans le tableau des bordereaux avec des quantités aberrantes.

---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/37a331c647a38a191b2a1207?card=tra-12339)
