### PR TITLE
Ne plus afficher les déchets non dangereux dans les déchets sur site

### DIFF
--- a/src/sheets/graph_processors/html_components_processors.py
+++ b/src/sheets/graph_processors/html_components_processors.py
@@ -716,7 +716,7 @@ class StorageStatsProcessor:
 
         # Only positive differences are kept
         stock_by_waste_code = stock_by_waste_code[stock_by_waste_code > 0]
-        total_stock = format_number_str(stock_by_waste_code.sum(), precision=1)
+        total_stock = format_number_str(received.sum() - emitted.sum(), precision=1)
         stock_by_waste_code = stock_by_waste_code.apply(format_number_str, precision=1)
 
         # Data is enriched with waste description from the waste nomenclature

--- a/src/sheets/graph_processors/html_components_processors.py
+++ b/src/sheets/graph_processors/html_components_processors.py
@@ -684,7 +684,11 @@ class StorageStatsProcessor:
     def _preprocess_data(self) -> pd.Series:
         siret = self.company_siret
 
-        dfs_to_concat = [df for df in self.bs_data_dfs.values()]
+        dfs_to_concat = [
+            df
+            for bs_type, df in self.bs_data_dfs.items()
+            if bs_type != BSDD_NON_DANGEROUS
+        ]
 
         if len(dfs_to_concat) == 0:
             self.stock_by_waste_code = pd.Series()

--- a/src/sheets/tests/test_bsd_stats_processor.py
+++ b/src/sheets/tests/test_bsd_stats_processor.py
@@ -250,7 +250,7 @@ def test_bsd_stats_processor_multiple_quantity_variables(
     # Test initialization
     assert bs_processor.company_siret == siret
     assert isinstance(bs_processor.bs_data, pd.DataFrame)
-    assert bs_processor.quantity_variables_names == quantity_variables_names
+    assert set(bs_processor.quantity_variables_names) == set(quantity_variables_names)
     assert bs_processor.bs_revised_data is None
     assert bs_processor.packagings_data is None
 


### PR DESCRIPTION
Le composant de déchets sur site n'affiche maitnenant que les déchets dangereux.

- [ ] Mettre à jour le change log
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/37a331c647a38a191b2a1207?card=tra-12946)
