### PR TITLE
Fills NaN values for storage component

### DIFF
--- a/src/sheets/graph_processors/html_components_processors.py
+++ b/src/sheets/graph_processors/html_components_processors.py
@@ -728,6 +728,7 @@ class StorageStatsProcessor:
             how="left",
             validate="one_to_one",
         )
+        stock_by_waste_code["description"].fillna("", inplace=True)
 
         self.stock_by_waste_code = stock_by_waste_code
         self.total_stock = total_stock


### PR DESCRIPTION
Cette PR résous un problème qui empêche l'édition de la fiche lorsque le code déchet associé à un bordereau n'existe pas et/ou est mal formaté.

- [ ] Mettre à jour le change log
---

- [Ticket Favro]()
