### PR TITLE
Suppression du filtre par date dans les requêtes

### DIFF
--- a/src/sheets/data_processing.py
+++ b/src/sheets/data_processing.py
@@ -371,7 +371,11 @@ class SheetProcessor:
         )
         self.computed.private_individuals_collections_data = private_individuals_collections_table.build()
 
-        quantity_outliers_table = QuantityOutliersTableProcessor(self.bs_dfs, self.transporter_data_dfs)
+        quantity_outliers_table = QuantityOutliersTableProcessor(
+            self.bs_dfs,
+            self.transporter_data_dfs,
+            data_date_interval,
+        )
         self.computed.quantity_outliers_data = quantity_outliers_table.build()
 
         waste_processing_without_icpe_data = WasteProcessingWithoutICPEProcessor(

--- a/src/sheets/database.py
+++ b/src/sheets/database.py
@@ -77,8 +77,6 @@ def build_bsdd_query(siret: str, data_start_date: datetime, data_end_date: datet
         sql_bsdd_query_str,
         query_params={
             "siret": siret,
-            "data_start_date": data_start_date,
-            "data_end_date": data_end_date,
         },
         date_columns=bsd_date_params,
         dtypes=bs_dtypes,
@@ -92,8 +90,6 @@ def build_bsdd_non_dangerous_query(siret: str, data_start_date: datetime, data_e
         sql_bsdd_non_dangerous_query_str,
         query_params={
             "siret": siret,
-            "data_start_date": data_start_date,
-            "data_end_date": data_end_date,
         },
         date_columns=bsd_date_params,
         dtypes=bs_dtypes,
@@ -107,8 +103,6 @@ def build_revised_bsdd_query(company_id: str, data_start_date: datetime, data_en
         sql_revised_bsdd_query_str,
         query_params={
             "company_id": company_id,
-            "data_start_date": data_start_date,
-            "data_end_date": data_end_date,
         },
         date_columns=bsd_date_params,
     )
@@ -121,8 +115,6 @@ def build_bsdd_transporter_query_str(siret: str, data_start_date: datetime, data
         sql_bsdd_transporter_query_str,
         query_params={
             "siret": siret,
-            "data_start_date": data_start_date,
-            "data_end_date": data_end_date,
         },
         date_columns=bsd_date_params,
     )
@@ -135,8 +127,6 @@ def build_bsdd_non_dangerous_transporter_query_str(siret: str, data_start_date: 
         sql_bsdd_non_dangerous_transporter_query_str,
         query_params={
             "siret": siret,
-            "data_start_date": data_start_date,
-            "data_end_date": data_end_date,
         },
         date_columns=bsd_date_params,
     )
@@ -149,8 +139,6 @@ def build_bsda_query(siret: str, data_start_date: datetime, data_end_date: datet
         sql_bsda_query_str,
         query_params={
             "siret": siret,
-            "data_start_date": data_start_date,
-            "data_end_date": data_end_date,
         },
         date_columns=[
             *bsd_date_params,
@@ -165,8 +153,6 @@ def build_revised_bsda_query(company_id: str, data_start_date: datetime, data_en
         sql_revised_bsda_query_str,
         query_params={
             "company_id": company_id,
-            "data_start_date": data_start_date,
-            "data_end_date": data_end_date,
         },
         date_columns=bsd_date_params,
     )
@@ -179,8 +165,6 @@ def build_bsdasri_query(siret: str, data_start_date: datetime, data_end_date: da
         sql_bsdasri_query_str,
         query_params={
             "siret": siret,
-            "data_start_date": data_start_date,
-            "data_end_date": data_end_date,
         },
         date_columns=bsd_date_params,
     )
@@ -191,8 +175,6 @@ def build_bsff_query(siret: str, data_start_date: datetime, data_end_date: datet
         sql_bsff_query_str,
         query_params={
             "siret": siret,
-            "data_start_date": data_start_date,
-            "data_end_date": data_end_date,
         },
         date_columns=bsd_date_params,
     )
@@ -203,8 +185,6 @@ def build_bsff_packagings_query(siret: str, data_start_date: datetime, data_end_
         sql_bsff_packagings_query_str,
         query_params={
             "siret": siret,
-            "data_start_date": data_start_date,
-            "data_end_date": data_end_date,
         },
         date_columns=["operation_date", "acceptation_date"],
     )
@@ -215,8 +195,6 @@ def build_bsvhu_query(siret: str, data_start_date: datetime, data_end_date: date
         sql_bsvhu_query_str,
         query_params={
             "siret": siret,
-            "data_start_date": data_start_date,
-            "data_end_date": data_end_date,
         },
         date_columns=bsd_date_params,
     )

--- a/src/sheets/graph_processors/plotly_components_processors.py
+++ b/src/sheets/graph_processors/plotly_components_processors.py
@@ -38,7 +38,7 @@ class BsdQuantitiesGraph:
         bs_data: pd.DataFrame,
         data_date_interval: tuple[datetime, datetime],
         quantity_variables_names: list[str] = ["quantity_received"],
-        packagings_data: pd.DataFrame = None,
+        packagings_data: pd.DataFrame | None = None,
     ):
         self.bs_data = bs_data
         self.packagings_data = packagings_data
@@ -270,8 +270,10 @@ class BsdTrackedAndRevisedProcessor:
         SIRET number of the establishment for which the data is displayed (used for data preprocessing).
     bs_data: DataFrame
         DataFrame containing data for a given 'bordereau' type.
+    data_date_interval: tuple
+        Date interval to filter data.
     bs_revised_data: DataFrame
-        DataFrame containing list of revised 'bordereaux' for a given 'bordereau' type.
+        Optional DataFrame containing list of revised 'bordereaux' for a given 'bordereau' type.
     """
 
     def __init__(
@@ -279,7 +281,7 @@ class BsdTrackedAndRevisedProcessor:
         company_siret: str,
         bs_data: pd.DataFrame,
         data_date_interval: tuple[datetime, datetime],
-        bs_revised_data: pd.DataFrame = None,
+        bs_revised_data: pd.DataFrame | None = None,
     ) -> None:
         self.company_siret = company_siret
         self.bs_data = bs_data
@@ -316,7 +318,10 @@ class BsdTrackedAndRevisedProcessor:
         """Preprocess raw revised 'bordereaux' data to prepare it for plotting."""
         bs_revised_data = self.bs_revised_data
 
-        bs_revised_data = bs_revised_data[bs_revised_data["bs_id"].isin(self.bs_data["id"])]
+        bs_revised_data = bs_revised_data[
+            bs_revised_data["bs_id"].isin(self.bs_data["id"])
+            & (bs_revised_data["created_at"].between(*self.data_date_interval))
+        ]
         bs_revised_by_month = bs_revised_data.groupby(pd.Grouper(key="created_at", freq="1M")).bs_id.nunique()
 
         self.bs_revised_by_month = bs_revised_by_month
@@ -463,6 +468,8 @@ class WasteOriginProcessor:
         Dict with key being the 'bordereau' type and values the DataFrame containing the bordereau data.
     departements_regions_df: DataFrame
         Static data about regions and départements with their codes.
+    data_date_interval: tuple
+        Date interval to filter data.
     """
 
     def __init__(
@@ -610,6 +617,8 @@ class WasteOriginsMapProcessor:
         Static data about regions and départements with their codes.
     regions_geodata: GeoDataFrame
         GeoDataFrame including regions geometries.
+    data_date_interval: tuple
+        Date interval to filter data.
     """
 
     def __init__(
@@ -1389,6 +1398,8 @@ class TransportedQuantitiesGraphProcessor:
         Dict with key being the 'bordereau' type and values the DataFrame containing the bordereau data.
     data_date_interval: tuple
         Date interval to filter data.
+    packagings_data_df : pd.DataFrame | None
+        Optional parameter that represents a DataFrame containing data about BSFF packagings.
     """
 
     def __init__(
@@ -1397,7 +1408,7 @@ class TransportedQuantitiesGraphProcessor:
         transporters_data_df: Dict[str, pd.DataFrame],  # Handling new multi-modal Trackdéchets feature
         bs_data_dfs: Dict[str, pd.DataFrame],
         data_date_interval: tuple[datetime, datetime],
-        packagings_data_df: pd.DataFrame = None,
+        packagings_data_df: pd.DataFrame | None = None,
     ) -> None:
         self.company_siret = company_siret
         self.transporters_data_df = transporters_data_df

--- a/src/sheets/queries.py
+++ b/src/sheets/queries.py
@@ -31,7 +31,6 @@ where
     (emitter_company_siret = :siret
     or recipient_company_siret = :siret)
     and is_deleted = false
-    and created_at BETWEEN :data_start_date AND :data_end_date
     and status::text not in ('DRAFT', 'INITIAL')
     and (waste_details_code ~* '.*\*$' or waste_details_pop or waste_details_is_dangerous)
 order by
@@ -71,7 +70,6 @@ where
     (emitter_company_siret = :siret
     or recipient_company_siret = :siret)
     and is_deleted = false
-    and created_at BETWEEN :data_start_date AND :data_end_date
     and status::text not in ('DRAFT', 'INITIAL')
     and not (waste_details_code ~* '.*\*$' or waste_details_pop or waste_details_is_dangerous)
 order by
@@ -95,7 +93,6 @@ where
         or recipient_company_siret = :siret
         or transporter_company_siret = :siret
     )
-    and bordereau_created_at between :data_start_date and :data_end_date
     and (waste_details_code like '%*'
         or waste_details_pop
         or waste_details_is_dangerous)
@@ -119,7 +116,6 @@ where
         or recipient_company_siret = :siret
         or transporter_company_siret = :siret
     )
-    and bordereau_created_at between :data_start_date and :data_end_date
     and not (waste_details_code like '%*'
         or waste_details_pop
         or waste_details_is_dangerous)
@@ -177,7 +173,6 @@ where
         or worker_company_siret = :siret
         or transporter_company_siret = :siret)
     and is_deleted = false
-    and created_at BETWEEN :data_start_date AND :data_end_date
     and status::text not in ('DRAFT', 'INITIAL')
     and not is_draft
 order by
@@ -208,7 +203,6 @@ where
         or destination_company_siret = :siret
         or transporter_company_siret = :siret)
     and is_deleted = false
-    and created_at BETWEEN :data_start_date AND :data_end_date
     and status::text not in ('DRAFT', 'INITIAL')
     and not is_draft
 order by
@@ -235,11 +229,9 @@ where
         or destination_company_siret = :siret
         or transporter_company_siret = :siret)
     and is_deleted = false
-    and created_at BETWEEN :data_start_date AND :data_end_date
     and status::text not in ('DRAFT', 'INITIAL')
     and not is_draft
-order by
-    created_at asc"""
+"""
 
 sql_bsff_packagings_query_str = """
 select
@@ -264,11 +256,8 @@ where
         (emitter_company_siret = :siret
             or destination_company_siret = :siret)
         and is_deleted = false
-        and created_at BETWEEN :data_start_date AND :data_end_date
         and status::text not in ('DRAFT', 'INITIAL')
             and not is_draft
-        order by
-            created_at asc
 )
 """
 
@@ -295,11 +284,8 @@ where
         or destination_company_siret = :siret
         or transporter_company_siret = :siret)
     and is_deleted = false
-    and created_at BETWEEN :data_start_date AND :data_end_date
     and  status::text not in ('DRAFT', 'INITIAL')
     and not is_draft
-order by
-    created_at asc
 """
 
 sql_revised_bsdd_query_str = """
@@ -312,7 +298,6 @@ select id,
 from trusted_zone_trackdechets.bsdd_revision_request
 where authoring_company_id = :company_id
     and status='ACCEPTED'
-    and created_at BETWEEN :data_start_date AND :data_end_date
 """
 
 sql_revised_bsda_query_str = """
@@ -325,7 +310,6 @@ select id,
 from trusted_zone_trackdechets.bsda_revision_request
 where authoring_company_id = :company_id
     and status='ACCEPTED'
-    and created_at BETWEEN :data_start_date AND :data_end_date
 """
 
 sql_get_icpe_data = """


### PR DESCRIPTION
Auparavant les données été pré-filtrées côté base de données par date (en plus des autres filtres). Maintenant ce filtre est fait côté applicatif. Ceci corrige les cas où, par exemple, un borderau créé en dehors de l'intervalle de date choisi mais envoyé/reçu/traité dans l'intervalle de date n'était pas affiché.

Mise à jour des docstrings et du typage pour rattraper des manquements.

- [ ] Mettre à jour le change log
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b34c3fc79210a83db2dc1238?card=tra-13851)
