### PR TITLE
Add BSDA transporter data

### DIFF
--- a/src/sheets/data_processing.py
+++ b/src/sheets/data_processing.py
@@ -202,6 +202,7 @@ class SheetProcessor:
 
             stock_graph = BsdQuantitiesGraph(
                 self.siret,
+                bsd_type,
                 df,
                 data_date_interval,
                 quantity_variables_names=quantity_variables,
@@ -214,6 +215,7 @@ class SheetProcessor:
 
             stats_graph = BsdStatsProcessor(
                 self.siret,
+                bsd_type,
                 df,
                 data_date_interval,
                 quantity_variables_names=quantity_variables,

--- a/src/sheets/data_processing.py
+++ b/src/sheets/data_processing.py
@@ -11,11 +11,12 @@ from .data_extract import (
 )
 from .database import (
     build_bsda_query,
+    build_bsda_transporter_query,
     build_bsdasri_query,
     build_bsdd_non_dangerous_query,
-    build_bsdd_non_dangerous_transporter_query_str,
+    build_bsdd_non_dangerous_transporter_query,
     build_bsdd_query,
-    build_bsdd_transporter_query_str,
+    build_bsdd_transporter_query,
     build_bsff_packagings_query,
     build_bsff_query,
     build_bsvhu_query,
@@ -112,18 +113,19 @@ bsds_config = [
         "bsd_type": BSDD,
         "bs_data": build_bsdd_query,
         "bs_revised_data": build_revised_bsdd_query,
-        "bs_transporter_data": build_bsdd_transporter_query_str,
+        "bs_transporter_data": build_bsdd_transporter_query,
     },
     {
         "bsd_type": BSDD_NON_DANGEROUS,
         "bs_data": build_bsdd_non_dangerous_query,
         "bs_revised_data": build_revised_bsdd_query,
-        "bs_transporter_data": build_bsdd_non_dangerous_transporter_query_str,
+        "bs_transporter_data": build_bsdd_non_dangerous_transporter_query,
     },
     {
         "bsd_type": BSDA,
         "bs_data": build_bsda_query,
         "bs_revised_data": build_revised_bsda_query,
+        "bs_transporter_data": build_bsda_transporter_query,
     },
     {"bsd_type": BSDASRI, "bs_data": build_bsdasri_query},
     {
@@ -254,8 +256,6 @@ class SheetProcessor:
             # compute and store df in a dict
             df = bsd_config["bs_data"](
                 siret=self.computed.org_id,
-                data_start_date=self.data_start_date,
-                data_end_date=self.data_end_date,
             )
             self.bs_dfs[bsd_type] = df
 
@@ -263,8 +263,6 @@ class SheetProcessor:
             if bs_revised_data:
                 revised_df = bs_revised_data(
                     company_id=self.company_id,
-                    data_start_date=self.data_start_date,
-                    data_end_date=self.data_end_date,
                 )
                 if len(revised_df) > 0:
                     self.revised_bs_dfs[bsd_type] = revised_df
@@ -273,8 +271,6 @@ class SheetProcessor:
             if bs_transporter_data:
                 transporter_data_df = bs_transporter_data(
                     siret=self.computed.org_id,
-                    data_start_date=self.data_start_date,
-                    data_end_date=self.data_end_date,
                 )
                 if len(transporter_data_df) > 0:
                     self.transporter_data_dfs[bsd_type] = transporter_data_df
@@ -282,8 +278,6 @@ class SheetProcessor:
             if bsd_type == BSFF:
                 bsff_packagings_data = bsd_config.get("packagings_data")(
                     siret=self.computed.org_id,
-                    data_start_date=self.data_start_date,
-                    data_end_date=self.data_end_date,
                 )
                 if len(bsff_packagings_data) > 0:
                     self.bsff_packagings_df = bsff_packagings_data
@@ -400,7 +394,7 @@ class SheetProcessor:
         transporter_bordereaux_graph = TransporterBordereauxGraphProcessor(
             company_siret=self.siret,
             transporters_data_df=self.transporter_data_dfs,
-            bs_data_dfs={k: v for k, v in self.bs_dfs.items() if k not in [BSDD, BSDD_NON_DANGEROUS]},
+            bs_data_dfs={k: v for k, v in self.bs_dfs.items() if k not in [BSDD, BSDD_NON_DANGEROUS, BSDA]},
             data_date_interval=data_date_interval,
         )
         self.computed.transporter_bordereaux_stats_graph_data = transporter_bordereaux_graph.build()
@@ -408,7 +402,7 @@ class SheetProcessor:
         quantities_transported_graph = TransportedQuantitiesGraphProcessor(
             company_siret=self.siret,
             transporters_data_df=self.transporter_data_dfs,
-            bs_data_dfs={k: v for k, v in self.bs_dfs.items() if k not in [BSDD, BSDD_NON_DANGEROUS]},
+            bs_data_dfs={k: v for k, v in self.bs_dfs.items() if k not in [BSDD, BSDD_NON_DANGEROUS, BSDA]},
             data_date_interval=data_date_interval,
             packagings_data_df=self.bsff_packagings_df,
         )
@@ -417,7 +411,7 @@ class SheetProcessor:
         transporter_bordereaux_stats = TransporterBordereauxStatsProcessor(
             company_siret=self.siret,
             transporters_data_df=self.transporter_data_dfs,
-            bs_data_dfs={k: v for k, v in self.bs_dfs.items() if k not in [BSDD, BSDD_NON_DANGEROUS]},
+            bs_data_dfs={k: v for k, v in self.bs_dfs.items() if k not in [BSDD, BSDD_NON_DANGEROUS, BSDA]},
             data_date_interval=data_date_interval,
             packagings_data_df=self.bsff_packagings_df,
         )

--- a/src/sheets/data_processing.py
+++ b/src/sheets/data_processing.py
@@ -380,6 +380,7 @@ class SheetProcessor:
         bsda_worker_stats = BsdaWorkerStatsProcessor(
             company_siret=self.siret,
             bsda_data_df=self.bs_dfs[BSDA],
+            bsda_transporter_df=self.transporter_data_dfs[BSDA],
             data_date_interval=data_date_interval,
         )
         self.computed.bsda_worker_stats_data = bsda_worker_stats.build()

--- a/src/sheets/data_processing.py
+++ b/src/sheets/data_processing.py
@@ -382,7 +382,7 @@ class SheetProcessor:
         bsda_worker_stats = BsdaWorkerStatsProcessor(
             company_siret=self.siret,
             bsda_data_df=self.bs_dfs[BSDA],
-            bsda_transporter_df=self.transporter_data_dfs[BSDA],
+            bsda_transporter_df=self.transporter_data_dfs.get(BSDA),
             data_date_interval=data_date_interval,
         )
         self.computed.bsda_worker_stats_data = bsda_worker_stats.build()

--- a/src/sheets/database.py
+++ b/src/sheets/database.py
@@ -27,6 +27,7 @@ from .queries import (
     sql_get_vhu_agrement_data,
     sql_revised_bsda_query_str,
     sql_revised_bsdd_query_str,
+    sql_bsda_transporter_query_str,
 )
 
 wh_engine = create_engine(settings.WAREHOUSE_URL, pool_pre_ping=True)
@@ -50,9 +51,9 @@ bs_dtypes = {
 
 def build_query(
     query_str,
-    query_params: dict[str, Any] = None,
+    query_params: dict[str, Any] | None = None,
     date_columns=None,
-    dtypes: dict[str, Any] = None,
+    dtypes: dict[str, Any] | None = None,
 ):
     query = text(query_str)
 
@@ -72,7 +73,9 @@ def build_query(
     return df
 
 
-def build_bsdd_query(siret: str, data_start_date: datetime, data_end_date: datetime) -> pd.DataFrame:
+def build_bsdd_query(
+    siret: str,
+) -> pd.DataFrame:
     df = build_query(
         sql_bsdd_query_str,
         query_params={
@@ -85,7 +88,9 @@ def build_bsdd_query(siret: str, data_start_date: datetime, data_end_date: datet
     return df
 
 
-def build_bsdd_non_dangerous_query(siret: str, data_start_date: datetime, data_end_date: datetime) -> pd.DataFrame:
+def build_bsdd_non_dangerous_query(
+    siret: str,
+) -> pd.DataFrame:
     df = build_query(
         sql_bsdd_non_dangerous_query_str,
         query_params={
@@ -98,7 +103,9 @@ def build_bsdd_non_dangerous_query(siret: str, data_start_date: datetime, data_e
     return df
 
 
-def build_revised_bsdd_query(company_id: str, data_start_date: datetime, data_end_date: datetime):
+def build_revised_bsdd_query(
+    company_id: str,
+):
     df = build_query(
         sql_revised_bsdd_query_str,
         query_params={
@@ -110,7 +117,9 @@ def build_revised_bsdd_query(company_id: str, data_start_date: datetime, data_en
     return df
 
 
-def build_bsdd_transporter_query_str(siret: str, data_start_date: datetime, data_end_date: datetime):
+def build_bsdd_transporter_query(
+    siret: str,
+):
     df = build_query(
         sql_bsdd_transporter_query_str,
         query_params={
@@ -122,7 +131,9 @@ def build_bsdd_transporter_query_str(siret: str, data_start_date: datetime, data
     return df
 
 
-def build_bsdd_non_dangerous_transporter_query_str(siret: str, data_start_date: datetime, data_end_date: datetime):
+def build_bsdd_non_dangerous_transporter_query(
+    siret: str,
+):
     df = build_query(
         sql_bsdd_non_dangerous_transporter_query_str,
         query_params={
@@ -134,7 +145,9 @@ def build_bsdd_non_dangerous_transporter_query_str(siret: str, data_start_date: 
     return df
 
 
-def build_bsda_query(siret: str, data_start_date: datetime, data_end_date: datetime) -> pd.DataFrame:
+def build_bsda_query(
+    siret: str,
+) -> pd.DataFrame:
     return build_query(
         sql_bsda_query_str,
         query_params={
@@ -148,7 +161,23 @@ def build_bsda_query(siret: str, data_start_date: datetime, data_end_date: datet
     )
 
 
-def build_revised_bsda_query(company_id: str, data_start_date: datetime, data_end_date: datetime):
+def build_bsda_transporter_query(
+    siret: str,
+):
+    df = build_query(
+        sql_bsda_transporter_query_str,
+        query_params={
+            "siret": siret,
+        },
+        date_columns=bsd_date_params,
+    )
+
+    return df
+
+
+def build_revised_bsda_query(
+    company_id: str,
+):
     df = build_query(
         sql_revised_bsda_query_str,
         query_params={
@@ -160,7 +189,9 @@ def build_revised_bsda_query(company_id: str, data_start_date: datetime, data_en
     return df
 
 
-def build_bsdasri_query(siret: str, data_start_date: datetime, data_end_date: datetime) -> pd.DataFrame:
+def build_bsdasri_query(
+    siret: str,
+) -> pd.DataFrame:
     return build_query(
         sql_bsdasri_query_str,
         query_params={
@@ -170,7 +201,9 @@ def build_bsdasri_query(siret: str, data_start_date: datetime, data_end_date: da
     )
 
 
-def build_bsff_query(siret: str, data_start_date: datetime, data_end_date: datetime) -> pd.DataFrame:
+def build_bsff_query(
+    siret: str,
+) -> pd.DataFrame:
     return build_query(
         sql_bsff_query_str,
         query_params={
@@ -180,7 +213,9 @@ def build_bsff_query(siret: str, data_start_date: datetime, data_end_date: datet
     )
 
 
-def build_bsff_packagings_query(siret: str, data_start_date: datetime, data_end_date: datetime) -> pd.DataFrame:
+def build_bsff_packagings_query(
+    siret: str,
+) -> pd.DataFrame:
     return build_query(
         sql_bsff_packagings_query_str,
         query_params={
@@ -190,7 +225,9 @@ def build_bsff_packagings_query(siret: str, data_start_date: datetime, data_end_
     )
 
 
-def build_bsvhu_query(siret: str, data_start_date: datetime, data_end_date: datetime) -> pd.DataFrame:
+def build_bsvhu_query(
+    siret: str,
+) -> pd.DataFrame:
     return build_query(
         sql_bsvhu_query_str,
         query_params={

--- a/src/sheets/database.py
+++ b/src/sheets/database.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import Any, Union
 
 import pandas as pd

--- a/src/sheets/graph_processors/html_components_processors.py
+++ b/src/sheets/graph_processors/html_components_processors.py
@@ -1673,7 +1673,7 @@ class BsdaWorkerStatsProcessor:
             )
 
     def _check_empty_data(self) -> bool:
-        if all(e is None for e in self.bsda_worker_stats.values()):
+        if all(e in [None, 0] for e in self.bsda_worker_stats.values()):
             return True
 
         return False

--- a/src/sheets/graph_processors/html_components_processors.py
+++ b/src/sheets/graph_processors/html_components_processors.py
@@ -1659,7 +1659,11 @@ class BsdaWorkerStatsProcessor:
                 2,
             )
 
-        times_to_process_from_emission = df["processed_at"] - df["emitter_emission_signature_date"]
+        df_filtered = df[
+            df["processed_at"].between(*self.data_date_interval)
+            & df["emitter_emission_signature_date"].between(*self.data_date_interval)
+        ]
+        times_to_process_from_emission = df_filtered["processed_at"] - df_filtered["emitter_emission_signature_date"]
         max_time_to_process_from_emission = times_to_process_from_emission.max()
         avg_time_to_process_from_emission = times_to_process_from_emission.mean()
 
@@ -1674,6 +1678,9 @@ class BsdaWorkerStatsProcessor:
             )
 
         df = df.merge(df_transporter, left_on="id", right_on="bs_id", validate="one_to_one", how="left")
+        df_filtered = df[
+            df["processed_at"].between(*self.data_date_interval) & df["sent_at"].between(*self.data_date_interval)
+        ]
         times_to_process_from_sending = df["processed_at"] - df["sent_at"]
         max_time_to_process_from_sending = times_to_process_from_sending.max()
         avg_time_to_process_from_sending = times_to_process_from_sending.mean()
@@ -1689,7 +1696,7 @@ class BsdaWorkerStatsProcessor:
             )
 
     def _check_empty_data(self) -> bool:
-        if all(e in [None, 0] for e in self.bsda_worker_stats.values()):
+        if all(e in [None, 0, "0"] for e in self.bsda_worker_stats.values()):
             return True
 
         return False

--- a/src/sheets/graph_processors/html_components_processors.py
+++ b/src/sheets/graph_processors/html_components_processors.py
@@ -1639,14 +1639,14 @@ class BsdaWorkerStatsProcessor:
         )
         self.bsda_worker_stats["signed_worker"] = len(
             df[
-                df["emitter_emission_signature_date"].notna()
+                df["emitter_emission_signature_date"].between(*self.data_date_interval)
                 & df["worker_work_signature_date"].between(*self.data_date_interval)
             ]
         )
         self.bsda_worker_stats["signed_transporter"] = len(
             df[
-                df["emitter_emission_signature_date"].notna()
-                & df["worker_work_signature_date"].notna()
+                df["emitter_emission_signature_date"].between(*self.data_date_interval)
+                & df["worker_work_signature_date"].between(*self.data_date_interval)
                 & df["transporter_transport_signature_date"].between(*self.data_date_interval)
             ]
         )

--- a/src/sheets/graph_processors/html_components_processors.py
+++ b/src/sheets/graph_processors/html_components_processors.py
@@ -1617,7 +1617,13 @@ class BsdaWorkerStatsProcessor:
         siret = self.company_siret
 
         df = self.bsda_data_df
+        if len(df) == 0:
+            return
+
         df_transporter = self.bsda_transporter_df
+        if (df_transporter is None) or (len(df_transporter) == 0):
+            return
+
         df_transporter = df_transporter.groupby("bs_id", as_index=False).agg({"sent_at": "min"})
 
         if len(self.bsda_data_df) == 0:

--- a/src/sheets/graph_processors/plotly_components_processors.py
+++ b/src/sheets/graph_processors/plotly_components_processors.py
@@ -1454,6 +1454,7 @@ class TransportedQuantitiesGraphProcessor:
                 if (bs_type == BSFF) and (self.packagings_data_df is not None):
                     df_by_month = (
                         df.merge(self.packagings_data_df, left_on="id", right_on="bsff_id")
+                        .dropna(subset="acceptation_date")
                         .groupby(pd.Grouper(key="acceptation_date", freq="1M"))["acceptation_weight"]
                         .sum()
                     )

--- a/src/sheets/graph_processors/plotly_components_processors.py
+++ b/src/sheets/graph_processors/plotly_components_processors.py
@@ -35,12 +35,14 @@ class BsdQuantitiesGraph:
     def __init__(
         self,
         company_siret: str,
+        bs_type: str,
         bs_data: pd.DataFrame,
         data_date_interval: tuple[datetime, datetime],
         quantity_variables_names: list[str] = ["quantity_received"],
         packagings_data: pd.DataFrame | None = None,
     ):
         self.bs_data = bs_data
+        self.bs_type = bs_type
         self.packagings_data = packagings_data
         self.company_siret = company_siret
         self.data_date_interval = data_date_interval
@@ -93,7 +95,10 @@ class BsdQuantitiesGraph:
             # If there is a packagings_data DataFrame, then it means that we are
             # computing BSFF statistics, in this case we use the packagings data instead of
             # 'bordereaux' data as quantity information is stored at packaging level
-            if self.packagings_data is not None:
+            if self.bs_type == BSFF:
+                if self.packagings_data is None:
+                    # Case when there is BSFFs but no packagings info
+                    continue
                 incoming_data_by_month = (
                     incoming_data.merge(self.packagings_data, left_on="id", right_on="bsff_id")
                     .groupby(pd.Grouper(key="acceptation_date", freq="1M"))[variable_name]

--- a/src/sheets/graph_processors/plotly_components_processors.py
+++ b/src/sheets/graph_processors/plotly_components_processors.py
@@ -80,9 +80,12 @@ class BsdQuantitiesGraph:
             (bs_data["recipient_company_siret"] == self.company_siret)
             & bs_data["received_at"].between(*self.data_date_interval)
         ]
+
+        # Handle the case of BSDA having transported date in separate table, to avoid use transporter data
+        sent_at_key = "sent_at" if ("sent_at" in bs_data.columns) else "transporter_transport_signature_date"
         outgoing_data = bs_data[
             (bs_data["emitter_company_siret"] == self.company_siret)
-            & bs_data["sent_at"].between(*self.data_date_interval)
+            & bs_data[sent_at_key].between(*self.data_date_interval)
         ]
 
         # We iterate over the different variables chosen to compute the statistics
@@ -111,7 +114,9 @@ class BsdQuantitiesGraph:
                 )
 
                 outgoing_data_by_month = (
-                    outgoing_data.groupby(pd.Grouper(key="sent_at", freq="1M"))[variable_name].sum().replace(0, np.nan)
+                    outgoing_data.groupby(pd.Grouper(key=sent_at_key, freq="1M"))[variable_name]
+                    .sum()
+                    .replace(0, np.nan)
                 )
 
             self.incoming_data_by_month_series.append(incoming_data_by_month)
@@ -297,12 +302,14 @@ class BsdTrackedAndRevisedProcessor:
         """Preprocess raw 'bordereaux' data to prepare it for plotting."""
         bs_data = self.bs_data
 
+        # Handle the case of BSDA having transported date in separate table, to avoid use transporter data
+        sent_at_key = "sent_at" if ("sent_at" in bs_data.columns) else "transporter_transport_signature_date"
         bs_emitted = bs_data[
             (bs_data["emitter_company_siret"] == self.company_siret)
-            & bs_data["sent_at"].between(*self.data_date_interval)
-        ].dropna(subset=["sent_at"])
+            & bs_data[sent_at_key].between(*self.data_date_interval)
+        ].dropna(subset=[sent_at_key])
 
-        bs_emitted_by_month = bs_emitted.groupby(pd.Grouper(key="sent_at", freq="1M")).id.count()
+        bs_emitted_by_month = bs_emitted.groupby(pd.Grouper(key=sent_at_key, freq="1M")).id.count()
 
         bs_received = bs_data[
             (bs_data["recipient_company_siret"] == self.company_siret)
@@ -1071,8 +1078,8 @@ class BsdaWorkerQuantityProcessor:
         )
 
         self.quantities_transported_by_month = (
-            bsda_data[bsda_data["sent_at"].between(*self.data_date_interval)]
-            .groupby(pd.Grouper(key="sent_at", freq="1M"))["quantity_received"]
+            bsda_data[bsda_data["transporter_transport_signature_date"].between(*self.data_date_interval)]
+            .groupby(pd.Grouper(key="transporter_transport_signature_date", freq="1M"))["quantity_received"]
             .sum()
         )
 
@@ -1253,7 +1260,7 @@ class TransporterBordereauxGraphProcessor:
             ]
 
             if len(df) > 0:
-                id_col = "form_id" if bs_type in [BSDD, BSDD_NON_DANGEROUS] else "id"
+                id_col = "bs_id" if bs_type in [BSDD, BSDD_NON_DANGEROUS, BSDA] else "id"
                 df_by_month = df.groupby(pd.Grouper(key="sent_at", freq="1M"))[id_col].nunique()
                 self.transported_bordereaux_stats[bs_type] = df_by_month
 

--- a/src/sheets/queries.py
+++ b/src/sheets/queries.py
@@ -79,7 +79,7 @@ order by
 sql_bsdd_transporter_query_str = r"""
 select
     id,
-    form_id,
+    form_id as bs_id,
     taken_over_at as sent_at,
     transporter_company_siret,
     transporter_number_plate,
@@ -102,7 +102,7 @@ where
 sql_bsdd_non_dangerous_transporter_query_str = r"""
 select
     id,
-    form_id,
+    form_id as bs_id,
     taken_over_at as sent_at,
     transporter_company_siret,
     transporter_number_plate,
@@ -145,7 +145,6 @@ select
     emitter_emission_signature_date,
     worker_work_signature_date,
     transporter_transport_signature_date,
-    transporter_transport_taken_over_at as sent_at,
     destination_reception_date as received_at,
     destination_operation_date as processed_at,
     emitter_company_siret,
@@ -177,6 +176,26 @@ where
     and not is_draft
 order by
     created_at asc"""
+
+sql_bsda_transporter_query_str = r"""
+select
+    id,
+    bsda_id as bs_id,
+    transporter_transport_taken_over_at as sent_at,
+    transporter_company_siret,
+    transporter_transport_plates,
+    transporter_transport_mode,
+    destination_reception_weight as quantity_received,
+    waste_code
+from
+    refined_zone_enriched.bsda_transporter_enriched
+where
+    (emitter_company_siret = :siret
+        or destination_company_siret = :siret
+        or transporter_company_siret = :siret
+    )
+    and waste_code like '%*'
+"""
 
 sql_bsdasri_query_str = """
 select

--- a/src/sheets/tests/test_bsd_stats_processor.py
+++ b/src/sheets/tests/test_bsd_stats_processor.py
@@ -4,6 +4,8 @@ from datetime import datetime, timedelta
 import pandas as pd
 import pytest
 
+from sheets.constants import BSDD
+
 from ..graph_processors.html_components_processors import BsdStatsProcessor
 
 
@@ -176,7 +178,7 @@ def data_date_interval():
     ],
 )
 def test_bsd_stats_processor(siret, sample_bs_data, data_date_interval, expected):
-    bs_processor = BsdStatsProcessor(siret, sample_bs_data, data_date_interval)
+    bs_processor = BsdStatsProcessor(siret, BSDD, sample_bs_data, data_date_interval)
 
     # Test initialization
     assert bs_processor.company_siret == siret
@@ -239,6 +241,7 @@ def test_bsd_stats_processor_multiple_quantity_variables(
 ):
     bs_processor = BsdStatsProcessor(
         siret,
+        BSDD,
         sample_bs_data,
         data_date_interval,
         quantity_variables_names=quantity_variables_names,
@@ -272,7 +275,7 @@ def test_bsd_stats_processor_multiple_quantity_variables(
 )
 def test_bsd_stats_processor_empty_data(siret, sample_bs_data_empty, data_date_interval, expected):
     # Test when the input data is empty
-    bs_processor = BsdStatsProcessor(siret, sample_bs_data_empty, data_date_interval)
+    bs_processor = BsdStatsProcessor(siret, BSDD, sample_bs_data_empty, data_date_interval)
     bs_processor._preprocess_data()
     assert bs_processor._check_data_empty() is True
 

--- a/src/templates/sheets/components/bs_without_icpe_authorization_tables.html
+++ b/src/templates/sheets/components/bs_without_icpe_authorization_tables.html
@@ -9,7 +9,7 @@
                 pour autant, vous trouverez ci-aprés la liste de <b>{{ bs_data_2760.stats.total_bs }}</b> bordereau{{ bs_data_2760.stats.total_bs|pluralize:"x" }} dont l'entreprise, destinataire, a indiqué D5 comme traitement.
             </p>
             <div {% if graph_context == "web" %}class="fr-table "{% endif %}>
-                <table {% if graph_context == "web" %}{% else %}class="pdf-table"{% endif %}>
+                <table {% if graph_context != "web" %}class="pdf-table"{% endif %}>
                     <thead>
                         <tr>
                             <th scope="col">N° du bordereau</th>
@@ -47,7 +47,7 @@
                 pour autant, vous trouverez ci-aprés la liste de <b>{{ bs_data_2770.stats.total_bs }}</b> bordereau{{ bs_data_2770.stats.total_bs|pluralize:"x" }} dont l'entreprise, destinataire, a indiqué R1 ou D10 comme traitement.
             </p>
             <div {% if graph_context == "web" %}class="fr-table "{% endif %}>
-                <table {% if graph_context == "web" %}{% else %}class="pdf-table"{% endif %}>
+                <table {% if graph_context != "web" %}class="pdf-table"{% endif %}>
                     <thead>
                         <tr>
                             <th scope="col">N° du bordereau</th>
@@ -88,7 +88,7 @@
                 a indiqué D13, D14, D15, R12 ou R13 comme traitement.
             </p>
             <div {% if graph_context == "web" %}class="fr-table "{% endif %}>
-                <table {% if graph_context == "web" %}{% else %}class="pdf-table"{% endif %}>
+                <table {% if graph_context != "web" %}class="pdf-table"{% endif %}>
                     <thead>
                         <tr>
                             <th scope="col">N° du bordereau</th>
@@ -129,7 +129,7 @@
                 a indiqué R2, R3, R4, R5, R6, R7, R9 ou D9 (final) comme traitement.
             </p>
             <div {% if graph_context == "web" %}class="fr-table "{% endif %}>
-                <table {% if graph_context == "web" %}{% else %}class="pdf-table"{% endif %}>
+                <table {% if graph_context != "web" %}class="pdf-table"{% endif %}>
                     <thead>
                         <tr>
                             <th scope="col">N° du bordereau</th>

--- a/src/templates/sheets/components/bsd_canceled_table.html
+++ b/src/templates/sheets/components/bsd_canceled_table.html
@@ -1,7 +1,7 @@
 {% if bsd_canceled_data %}
     <h2 class="section__title">Liste des bordereaux annulés</h2>
     <div {% if graph_context == "web" %}class="fr-table "{% endif %}>
-        <table {% if graph_context == "web" %}{% else %}class="pdf-table"{% endif %}>
+        <table {% if graph_context != "web" %}class="pdf-table"{% endif %}>
             <thead>
                 <tr>
                     <th scope="col">Numéro de bordereau</th>

--- a/src/templates/sheets/components/bsda_worker_bordereaux_counts_stats.html
+++ b/src/templates/sheets/components/bsda_worker_bordereaux_counts_stats.html
@@ -7,7 +7,7 @@
 <h3 class="cell__title">Statistiques en tant qu'entreprise de travaux - Nombre de BSDA</h3>
 {% if bsda_worker_stats_data %}
     <div {% if graph_context == "web" %}class="fr-table "{% endif %}>
-        <table {% if graph_context == "web" %}{% else %}class="pdf-table"{% endif %}>
+        <table {% if graph_context != "web" %}class="pdf-table"{% endif %}>
             <thead>
                 <tr>
                     <th class="table-headline" scope="col">Statut du BSDA</th>

--- a/src/templates/sheets/components/bsda_worker_bordereaux_durations_stats.html
+++ b/src/templates/sheets/components/bsda_worker_bordereaux_durations_stats.html
@@ -7,7 +7,7 @@
 <h3 class="cell__title">Statistiques en tant qu'entreprise de travaux - Durées</h3>
 {% if bsda_worker_stats_data %}
     <div {% if graph_context == "web" %}class="fr-table "{% endif %}>
-        <table {% if graph_context == "web" %}{% else %}class="pdf-table"{% endif %}>
+        <table {% if graph_context != "web" %}class="pdf-table"{% endif %}>
             <thead>
                 <tr>
                     <th class="table-headline" scope="col">Durée en jours</th>

--- a/src/templates/sheets/components/followed_with_pnttd_table.html
+++ b/src/templates/sheets/components/followed_with_pnttd_table.html
@@ -3,7 +3,7 @@
         <h3>Données Trackdéchets</h3>
         <p>Liste des déchets dont la destination ultérieure prévue est à l'étranger :</p>
         <div {% if graph_context == "web" %}class="fr-table "{% endif %}>
-            <table {% if graph_context == "web" %}{% else %}class="pdf-table"{% endif %}>
+            <table {% if graph_context != "web" %}class="pdf-table"{% endif %}>
                 <thead>
                     <tr>
                         <th scope="col">SIRET ou N° de TVA du destinataire</th>

--- a/src/templates/sheets/components/gistrid_stats_table.html
+++ b/src/templates/sheets/components/gistrid_stats_table.html
@@ -5,7 +5,7 @@
         {% if gistrid_stats_data.import %}
             <h4>Importations</h4>
             <div {% if graph_context == "web" %}class="fr-table "{% endif %}>
-                <table {% if graph_context == "web" %}{% else %}class="pdf-table"{% endif %}>
+                <table {% if graph_context != "web" %}class="pdf-table"{% endif %}>
                     <thead>
                         <tr>
                             <th scope="col">Annee de fin autorisée des échanges</th>
@@ -40,7 +40,7 @@
         {% if gistrid_stats_data.export %}
             <h4>Exportations</h4>
             <div {% if graph_context == "web" %}class="fr-table "{% endif %}>
-                <table {% if graph_context == "web" %}{% else %}class="pdf-table"{% endif %}>
+                <table {% if graph_context != "web" %}class="pdf-table"{% endif %}>
                     <thead>
                         <tr>
                             <th scope="col">Annee de fin autorisée des échanges</th>

--- a/src/templates/sheets/components/icpe.html
+++ b/src/templates/sheets/components/icpe.html
@@ -2,7 +2,7 @@
     <h3>Listes des rubriques des installations associées à l'établissement</h3>
     {% if  icpe_data %}
         <div {% if graph_context == "web" %}class="fr-table "{% endif %}>
-            <table {% if graph_context == "web" %}{% else %}class="pdf-table"{% endif %}>
+            <table {% if graph_context != "web" %}class="pdf-table"{% endif %}>
                 <thead>
                     <tr>
                         <th scope="col">Rubrique</th>

--- a/src/templates/sheets/components/linked_companies.html
+++ b/src/templates/sheets/components/linked_companies.html
@@ -1,25 +1,27 @@
 {% if linked_companies_data %}
-    <h3>Liste des autres établissements de la même entreprise (SIREN {{ linked_companies_data.siren }}) :</h3>
-    <div {% if graph_context == "web" %}class="fr-table"{% endif %}>
-        <table {% if graph_context == "web" %}{% else %}class="pdf-table"{% endif %}>
-            <thead>
-                <tr>
-                    <th scope="col">SIRET</th>
-                    <th scope="col">Nom</th>
-                    <th scope="col">Adresse</th>
-                    <th scope="col">Date de création</th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for row in linked_companies_data.siret_list %}
+    <div {% if graph_context == "web" %}class="cell cell--bordered cell--full"{% endif %}>
+        <h3>Liste des autres établissements de la même entreprise (SIREN {{ linked_companies_data.siren }}) :</h3>
+        <div {% if graph_context == "web" %}class="fr-table"{% endif %}>
+            <table {% if graph_context != "web" %}class="pdf-table"{% endif %}>
+                <thead>
                     <tr>
-                        <td>{{ row.siret }}</td>
-                        <td>{{ row.name }}</td>
-                        <td>{{ row.address }}</td>
-                        <td>{{ row.created_at }}</td>
+                        <th scope="col">SIRET</th>
+                        <th scope="col">Nom</th>
+                        <th scope="col">Adresse</th>
+                        <th scope="col">Date de création</th>
                     </tr>
-                {% endfor %}
-            </tbody>
-        </table>
+                </thead>
+                <tbody>
+                    {% for row in linked_companies_data.siret_list %}
+                        <tr>
+                            <td>{{ row.siret }}</td>
+                            <td>{{ row.name }}</td>
+                            <td>{{ row.address }}</td>
+                            <td>{{ row.created_at }}</td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
     </div>
 {% endif %}

--- a/src/templates/sheets/components/private_individuals_collections_table.html
+++ b/src/templates/sheets/components/private_individuals_collections_table.html
@@ -10,7 +10,7 @@
                         <th scope="col">SIRET de l'entreprise de travaux</th>
                     {% endif %}
                     <th scope="col">Date de l'envoi</th>
-                    <th scope="col">Date de la réception</th>
+                    {% if graph_context == "web" %}<th scope="col">Date de la réception</th>{% endif %}
                     <th scope="col">Nom de l'émetteur</th>
                     <th scope="col">Adresse de l'émetteur</th>
                     <th scope="col">Nom du chantier</th>
@@ -45,7 +45,7 @@
                             </td>
                         {% endif %}
                         <td>{{ row.sent_at|default:"N/A" }}</td>
-                        <td>{{ row.received_at|default:"N/A" }}</td>
+                        {% if graph_context == "web" %}<td>{{ row.received_at|default:"N/A" }}</td>{% endif %}
                         <td>{{ row.emitter_company_name|default:"N/A" }}</td>
                         <td>{{ row.emitter_company_address|default:"N/A" }}</td>
                         <td>{{ row.worksite_name|default:"N/A" }}</td>

--- a/src/templates/sheets/components/private_individuals_collections_table.html
+++ b/src/templates/sheets/components/private_individuals_collections_table.html
@@ -1,7 +1,7 @@
 {% if private_individuals_collections_data %}
     <h2 class="section__title">Liste des collectes chez les particuliers</h2>
     <div {% if graph_context == "web" %}class="fr-table "{% endif %}>
-        <table {% if graph_context == "web" %}{% else %}class="pdf-table"{% endif %}>
+        <table {% if graph_context != "web" %}class="pdf-table"{% endif %}>
             <thead>
                 <tr>
                     <th scope="col">Numéro de bordereau</th>

--- a/src/templates/sheets/components/quantity_outliers_table.html
+++ b/src/templates/sheets/components/quantity_outliers_table.html
@@ -4,7 +4,7 @@
         Une quantité est dite aberrante si elle dépasse 40t pour un BSDD, BSDA, BSVHU ou 20t pour un BSDASRI ou un BSFF.
     </div>
     <div {% if graph_context == "web" %}class="fr-table "{% endif %}>
-        <table {% if graph_context == "web" %}{% else %}class="pdf-table"{% endif %}>
+        <table {% if graph_context != "web" %}class="pdf-table"{% endif %}>
             <thead>
                 <tr>
                     <th scope="col">Type de bordereau</th>

--- a/src/templates/sheets/components/quantity_outliers_table.html
+++ b/src/templates/sheets/components/quantity_outliers_table.html
@@ -27,14 +27,14 @@
                             {% if row.emitter_company_siret == company_siret %}
                                 <span class="fr-text--bold">{{ row.emitter_company_siret }}</span>
                             {% else %}
-                                {{ row.emitter_company_siret }}
+                                {{ row.emitter_company_siret|default:"N/A" }}
                             {% endif %}
                         </td>
                         <td>
                             {% if row.recipient_company_siret == company_siret %}
                                 <span class="fr-text--bold">{{ row.recipient_company_siret }}</span>
                             {% else %}
-                                {{ row.recipient_company_siret }}
+                                {{ row.recipient_company_siret|default:"N/A" }}
                             {% endif %}
                         </td>
                         <td>{{ row.sent_at|default:"N/A" }}</td>

--- a/src/templates/sheets/components/same_emitter_recipient_table.html
+++ b/src/templates/sheets/components/same_emitter_recipient_table.html
@@ -3,7 +3,7 @@
         Liste des bordereaux pour lesquels l'établissement s'est positionné en tant qu'émetteur et destinataire
     </h2>
     <div {% if graph_context == "web" %}class="fr-table "{% endif %}>
-        <table {% if graph_context == "web" %}{% else %}class="pdf-table"{% endif %}>
+        <table {% if graph_context != "web" %}class="pdf-table"{% endif %}>
             <thead>
                 <tr>
                     <th scope="col">Numéro de bordereau</th>

--- a/src/templates/sheets/components/traceabilty_break.html
+++ b/src/templates/sheets/components/traceabilty_break.html
@@ -6,7 +6,7 @@
             les déchets suivants:
         </p>
         <div {% if graph_context == "web" %}class="fr-table "{% endif %}>
-            <table {% if graph_context == "web" %}{% else %}class="pdf-table"{% endif %}>
+            <table {% if graph_context != "web" %}class="pdf-table"{% endif %}>
                 <thead>
                     <tr>
                         <th scope="col">Code déchet</th>

--- a/src/templates/sheets/components/transported_bordereaux_stats.html
+++ b/src/templates/sheets/components/transported_bordereaux_stats.html
@@ -7,7 +7,7 @@
 <h3 class="cell__title">Statistiques en tant que transporteur</h3>
 {% if transporter_bordereaux_stats_data %}
     <div {% if graph_context == "web" %}class="fr-table "{% endif %}>
-        <table {% if graph_context == "web" %}{% else %}class="pdf-table"{% endif %}>
+        <table {% if graph_context != "web" %}class="pdf-table"{% endif %}>
             <thead>
                 <tr>
                     <th class="table-headline" scope="col">Type de Bordereau</th>

--- a/src/templates/sheets/components/waste_flows_table.html
+++ b/src/templates/sheets/components/waste_flows_table.html
@@ -1,5 +1,5 @@
 <div {% if graph_context == "web" %}class="fr-table "{% endif %}>
-    <table {% if graph_context == "web" %}{% else %}class="pdf-table"{% endif %}>
+    <table {% if graph_context != "web" %}class="pdf-table"{% endif %}>
         <thead>
             <tr>
                 <th scope="col">Code déchet</th>

--- a/src/templates/sheets/components/waste_is_dangerous_statements.html
+++ b/src/templates/sheets/components/waste_is_dangerous_statements.html
@@ -2,7 +2,7 @@
 {% if waste_is_dangerous_statements_data %}
     <p>L'établissement a déclaré des déchets comme étant dangereux pour les codes déchets non dangereux suivants :</p>
     <div {% if graph_context == "web" %}class="fr-table "{% endif %}>
-        <table {% if graph_context == "web" %}{% else %}class="pdf-table"{% endif %}>
+        <table {% if graph_context != "web" %}class="pdf-table"{% endif %}>
             <thead>
                 <tr>
                     <th scope="col">Code déchet</th>

--- a/src/templates/sheets/sheet.html
+++ b/src/templates/sheets/sheet.html
@@ -50,7 +50,7 @@
         </div>
         <div class="row">
             {#  linked companies table #}
-            <div class="cell cell--bordered cell--full">{% render_linked_companies_data sheet %}</div>
+            {% render_linked_companies_data sheet %}
             {#  linked companies table #}
         </div>
         <h2 class="section__title" id="bs-section-title">

--- a/src/templates/sheets/sheetpdf.html
+++ b/src/templates/sheets/sheetpdf.html
@@ -328,12 +328,6 @@
             {# bsd canceled table #}
             <div>{% render_bsd_canceled_table sheet graph_context="pdf" %}</div>
             {# end bsd canceled table #}
-            {# same emitter recipient table #}
-            <div>{% render_same_emitter_recipient_table sheet graph_context="pdf" %}</div>
-            {# end same emitter recipient table #}
-            {#  private indivudals collections table #}
-            <div>{% render_private_individuals_collections_table sheet graph_context="pdf" %}</div>
-            {#  end private indivudals collections table #}
             {#  quantity outliers table #}
             <div>{% render_quantity_outliers_table sheet graph_context="pdf" %}</div>
             {# end quantity outliers table #}
@@ -343,6 +337,14 @@
                 {% render_waste_flows_table sheet graph_context="pdf" %}
             </div>
             {# endinput/output #}
+        </section>
+        <section class="horizontal">
+            {# same emitter recipient table #}
+            <div>{% render_same_emitter_recipient_table sheet graph_context="pdf" %}</div>
+            {# end same emitter recipient table #}
+            {#  private indivudals collections table #}
+            <div>{% render_private_individuals_collections_table sheet graph_context="pdf" %}</div>
+            {#  end private indivudals collections table #}
         </section>
     </div>
 {% endblock %}

--- a/src/templates/sheets/sheetpdf.html
+++ b/src/templates/sheets/sheetpdf.html
@@ -325,9 +325,6 @@
         {# Appendices section #}
         <section class="vertical">
             <h2 class="section__title">Annexes</h2>
-            {# bsd canceled table #}
-            <div>{% render_bsd_canceled_table sheet graph_context="pdf" %}</div>
-            {# end bsd canceled table #}
             {#  quantity outliers table #}
             <div>{% render_quantity_outliers_table sheet graph_context="pdf" %}</div>
             {# end quantity outliers table #}
@@ -339,6 +336,9 @@
             {# endinput/output #}
         </section>
         <section class="horizontal">
+            {# bsd canceled table #}
+            <div>{% render_bsd_canceled_table sheet graph_context="pdf" %}</div>
+            {# end bsd canceled table #}
             {# same emitter recipient table #}
             <div>{% render_same_emitter_recipient_table sheet graph_context="pdf" %}</div>
             {# end same emitter recipient table #}

--- a/src/templates/sheets/sheetpdf.html
+++ b/src/templates/sheets/sheetpdf.html
@@ -50,7 +50,7 @@
             </div>
             <div class="row">
                 {#  linked companies table #}
-                <div>{% render_linked_companies_data sheet graph_context="pdf" %}</div>
+                {% render_linked_companies_data sheet graph_context="pdf" %}
                 {#  end linked companies table #}
             </div>
             <h2 class="section-title">Données des bordereaux de suivi dématérialisés issues de Trackdéchets</h2>


### PR DESCRIPTION
Cette PR permet de prendre en compte le nouveau modèle de données de l'application Trackdéchets dans lequel maintenant les transporteurs BSDA sont stockés à part.  

Correction aussi d'un bug lorsque il y a des BSFF mais sans emballages, ils sont écartés.

Enfin optimisation de la mise en page des tableaux très larges en annexe.

- [ ] Mettre à jour le change log
---

- [Ticket Favro]()
