### PR TITLE
HOTFIX - Corrige un bug lorsqu'il y a prséence de NaT dans BSFF packagings

### DIFF
--- a/src/sheets/graph_processors/plotly_components_processors.py
+++ b/src/sheets/graph_processors/plotly_components_processors.py
@@ -1442,6 +1442,7 @@ class TransportedQuantitiesGraphProcessor:
                 if (bs_type == BSFF) and (self.packagings_data_df is not None):
                     df_by_month = (
                         df.merge(self.packagings_data_df, left_on="id", right_on="bsff_id")
+                        .dropna(subset="acceptation_date")
                         .groupby(pd.Grouper(key="acceptation_date", freq="1M"))["acceptation_weight"]
                         .sum()
                     )


### PR DESCRIPTION
Les lignes contenants des NaT sont maintenant écartées dans `WasteProcessingWithoutICPEProcessor`.

- [ ] Mettre à jour le change log
---

- [Ticket Favro]()
