### PR TITLE
Correction d'une erreur dans le calcul des stats BSFF

### DIFF
--- a/src/sheets/graph_processors/html_components_processors.py
+++ b/src/sheets/graph_processors/html_components_processors.py
@@ -140,7 +140,7 @@ class BsdStatsProcessor:
             df = to_process
 
             if self.bs_type == BSFF:
-                if (to_process_packagings is None) or (len(to_process_packagings) > 0):
+                if (to_process_packagings is None) or (len(to_process_packagings) == 0):
                     # Case when there is BSFFs but no packagings info
                     continue
                 df = (


### PR DESCRIPTION
Le calcul des stats n'était pas fait pour les BSFF suite à une typo dans le code.

- [ ] Mettre à jour le change log
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/37a331c647a38a191b2a1207?card=tra-14044)
