### PR TITLE
Correction d'un bug sur le composant FollowedWithPNTTDTableProcessor

### DIFF
--- a/src/sheets/graph_processors/html_components_processors.py
+++ b/src/sheets/graph_processors/html_components_processors.py
@@ -1884,6 +1884,7 @@ class FollowedWithPNTTDTableProcessor:
 
             final_df["quantity"] = final_df["quantity"].apply(lambda x: format_number_str(x, 2))
             final_df["description"] = final_df["description"].fillna("")
+            final_df = final_df.rename_axis(None, axis=0)
             self.preprocessed_df = final_df[
                 [
                     "foreign_org_id",


### PR DESCRIPTION
Un index portait le même nom qu'une colonne dans un dataframe pandas dans le composant `FollowedWithPNTTDTableProcessor` faisant planter le tri à la fin du traitement de données.
Le nom de l'index est maintenant supprimé.

- [ ] Mettre à jour le change log
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/37a331c647a38a191b2a1207?card=tra-14377)
