### PR TITLE
Supression des dernières colonnes transporteurs de la table BSDA

### DIFF
--- a/src/sheets/queries.py
+++ b/src/sheets/queries.py
@@ -157,20 +157,17 @@ select
     waste_material_name as waste_name,
     destination_operation_code as processing_operation_code,
     status,
-    transporter_transport_mode,
     waste_pop,
     emitter_pickup_site_name as worksite_name,
     emitter_pickup_site_address as worksite_address,
     worker_company_siret,
-    emitter_is_private_individual,
-    transporter_company_siret
+    emitter_is_private_individual
 from
     trusted_zone_trackdechets.bsda
 where
     (emitter_company_siret = :siret
         or destination_company_siret = :siret
-        or worker_company_siret = :siret
-        or transporter_company_siret = :siret)
+        or worker_company_siret = :siret)
     and is_deleted = false
     and status::text not in ('DRAFT', 'INITIAL')
     and not is_draft


### PR DESCRIPTION
Il restait quelques colonnes relative aux transporteurs dans la requpete des données BSDA.
Cette PR les supprime.
Les données de transport BSDA sont maintenant extraites de la table `bsda_transporter`.

- [ ] Mettre à jour le change log
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/37a331c647a38a191b2a1207?card=tra-14404)
