### PR TITLE
Changement esthétiques et correction d'un problème avec le PDF

### DIFF
--- a/src/sheets/views/sheet_views.py
+++ b/src/sheets/views/sheet_views.py
@@ -227,10 +227,15 @@ class SheetPdfHtml(FullyLoggedMixin, DetailView):
                 "waste_origin_map_graph": self.object.waste_origin_map_graph,
                 "icpe_2770_graph": self.object.icpe_2770_graph,
                 "icpe_2790_graph": self.object.icpe_2790_graph,
-                "icpe_2760_graph": self.object.icpe_2760_graph,
+                "icpe_2760_1_graph": self.object.icpe_2760_1_graph,
+                "icpe_2771_graph": self.object.icpe_2771_graph,
+                "icpe_2791_graph": self.object.icpe_2791_graph,
+                "icpe_2760_2_graph": self.object.icpe_2760_2_graph,
                 "bsda_worker_quantity_graph": self.object.bsda_worker_quantity_graph,
-                "bs_transported_graph": self.object.transporter_bordereaux_stats_graph,
-                "bs_quantities_transported_graph": self.object.quantities_transported_stats_graph,
+                "transporter_bordereaux_stats_graph": self.object.transporter_bordereaux_stats_graph,
+                "quantities_transported_stats_graph": self.object.quantities_transported_stats_graph,
+                "non_dangerous_waste_statements_graph": self.object.non_dangerous_waste_statements_graph,
+                "non_dangerous_waste_quantities_graph": self.object.non_dangerous_waste_quantities_graph,
             }
         )
         return ctx

--- a/src/templates/sheets/components/waste_flows_table.html
+++ b/src/templates/sheets/components/waste_flows_table.html
@@ -1,6 +1,6 @@
 <div {% if graph_context == "web" %}class="fr-table "{% endif %}>
     <div style="margin: 5px;">
-        <p class="fr-tag fr-tag--sm fr-icon-info-fill fr-tag--icon-left">Source : Trackdéchets et RNDTS</p>
+        <p class="fr-tag fr-tag fr-icon-info-fill fr-tag--icon-left">Source : Trackdéchets et RNDTS</p>
     </div>
     <table {% if graph_context != "web" %}class="pdf-table"{% endif %}>
         <thead>

--- a/src/templates/sheets/sheet.html
+++ b/src/templates/sheets/sheet.html
@@ -37,14 +37,11 @@
                 {% render_agreements sheet %}
             </div>
             <div class="cell cell--bordered cell--third">
-                <p>Les données pour cet établissement peuvent être consultées sur Trackdéchets</p>
-                <p>
-                    Elles comprennent les bordereaux de suivi de déchets (BSD) dématérialisés, mais ne comprennent pas
-                    :
-                </p>
+                <p>Les données présentes dans cette fiche proviennent de différentes sources :</p>
                 <ul>
-                    <li>les éventuels BSD papiers non dématérialisés</li>
-                    <li>les bons d’enlèvements (huiles usagées et pneus)</li>
+                    <li>Trackdéchets (mise à jour chaque nuit) ;</li>
+                    <li>l'outil GUN (dernière mise à jour : janvier 2024) ;</li>
+                    <li>le RNDTS (dernière mise à jour : avril 2024).</li>
                 </ul>
             </div>
         </div>
@@ -205,6 +202,7 @@
             </div>
         {% endif %}
         {# end BSDA worker stats #}
+        {# transporter #}
         {% if sheet.transporter_bordereaux_stats_graph_data %}
             <div class="row">
                 <div class="cell cell--bordered cell--third">
@@ -222,6 +220,12 @@
                 <div class="cell cell--bordered cell--third">{% render_transported_bordereaux_stats_data sheet %}</div>
             </div>
         {% endif %}
+        {# end transporter #}
+        {# "waste is dangerous" statements #}
+        {% if sheet.waste_is_dangerous_statements_data %}
+            <div class="cell cell--bordered cell--half">{% render_waste_is_dangerous_statements sheet %}</div>
+        {% endif %}
+        {# end "waste is dangerous" statements #}
         {# DND #}
         <h2 class="section__title" id="bs-section-title">Données des déclarations issues du RNDTS</h2>
         <p class="fr-tag fr-tag fr-icon-info-fill fr-tag--icon-left">Dernière mise à jour des données : Avril 2024</p>
@@ -248,11 +252,6 @@
             <div class="no-data-section">PAS DE DONNÉES ISSUES DU RNDTS À AFFICHER POUR LE SIRET {{ sheet.org_id }}.</div>
         {% endif %}
         {# end DND #}
-        {# "waste is dangerous" statements #}
-        {% if sheet.waste_is_dangerous_statements_data %}
-            <div class="cell cell--bordered cell--half">{% render_waste_is_dangerous_statements sheet %}</div>
-        {% endif %}
-        {# end "waste is dangerous" statements #}
         <h2 class="section__title">Déchets sur site (théorique)</h2>
         <div class="row">
             <div class="cell cell--bordered cell--third">

--- a/src/templates/sheets/sheetpdf.html
+++ b/src/templates/sheets/sheetpdf.html
@@ -36,15 +36,11 @@
                     {% render_agreements sheet %}
                 </div>
                 <div class="cell cell--third">
-                    <p class="pdf-text">Les données pour cet établissement peuvent être consultées sur Trackdéchets</p>
-                    <p class="pdf-text">
-                        Elles comprennent les bordereaux de suivi de déchets (BSD) dématérialisés, mais ne comprennent
-                        pas
-                        :
-                    </p>
+                    <p class="pdf-text">Les données présentes dans cette fiche proviennent de différentes sources :</p>
                     <ul class="pdf-text">
-                        <li>les éventuels BSD papiers non dématérialisés</li>
-                        <li>les bons d’enlèvements (huiles usagées et pneus)</li>
+                        <li>Trackdéchets (mise à jour chaque nuit) ;</li>
+                        <li>l'outil GUN (dernière mise à jour : janvier 2024) ;</li>
+                        <li>le RNDTS (dernière mise à jour : avril 2024).</li>
                     </ul>
                 </div>
             </div>
@@ -188,6 +184,7 @@
                 </div>
             {% endif %}
             {# end BSDA worker stats #}
+            {# transporter #}
             {% if sheet.transporter_bordereaux_stats_graph_data %}
                 <div class="row">
                     <div class="cell cell--bordered cell--third">
@@ -205,6 +202,12 @@
                     </div>
                 </div>
             {% endif %}
+            {# end transporter #}
+            {#  "waste is dangerous" statements #}
+            {% if sheet.waste_is_dangerous_statements_data %}
+                <div>{% render_waste_is_dangerous_statements sheet graph_context="pdf" %}</div>
+            {% endif %}
+            {# end "waste is dangerous" statements #}
             {# DND #}
             <h2 class="section__title" id="bs-section-title">Données des déclarations issues du RNDTS</h2>
             <p class="fr-tag fr-tag fr-icon-info-fill fr-tag--icon-left">Dernière mise à jour des données : Avril 2024</p>
@@ -229,11 +232,6 @@
                 <div class="no-data-section">PAS DE DONNÉES ISSUES DU RNDTS À AFFICHER POUR LE SIRET {{ sheet.org_id }}.</div>
             {% endif %}
             {# end DND #}
-            {#  "waste is dangerous" statements #}
-            {% if sheet.waste_is_dangerous_statements_data %}
-                <div>{% render_waste_is_dangerous_statements sheet graph_context="pdf" %}</div>
-            {% endif %}
-            {# end "waste is dangerous" statements #}
             {#  on site #}
             <h2 class="section__title">Déchets sur site (théorique)</h2>
             <div class="row">
@@ -385,26 +383,28 @@
         {# Appendices section #}
         <section class="vertical">
             <h2 class="section__title">Annexes</h2>
-            {#  quantity outliers table #}
-            <div>{% render_quantity_outliers_table sheet graph_context="pdf" %}</div>
-            {# end quantity outliers table #}
             {# input/output #}
             <div>
                 <h3>Liste des déchets entrants, sortants et transportés</h3>
                 {% render_waste_flows_table sheet graph_context="pdf" %}
             </div>
             {# endinput/output #}
+            {#  quantity outliers table #}
+            <div>{% render_quantity_outliers_table sheet graph_context="pdf" %}</div>
+            {# end quantity outliers table #}
         </section>
-        <section class="horizontal">
-            {# bsd canceled table #}
-            <div>{% render_bsd_canceled_table sheet graph_context="pdf" %}</div>
-            {# end bsd canceled table #}
-            {# same emitter recipient table #}
-            <div>{% render_same_emitter_recipient_table sheet graph_context="pdf" %}</div>
-            {# end same emitter recipient table #}
-            {#  private indivudals collections table #}
-            <div>{% render_private_individuals_collections_table sheet graph_context="pdf" %}</div>
-            {#  end private indivudals collections table #}
-        </section>
+        {% if render_bsd_canceled_table or render_same_emitter_recipient_table or render_private_individuals_collections_table %}
+            <section class="horizontal">
+                {# bsd canceled table #}
+                <div>{% render_bsd_canceled_table sheet graph_context="pdf" %}</div>
+                {# end bsd canceled table #}
+                {# same emitter recipient table #}
+                <div>{% render_same_emitter_recipient_table sheet graph_context="pdf" %}</div>
+                {# end same emitter recipient table #}
+                {#  private indivudals collections table #}
+                <div>{% render_private_individuals_collections_table sheet graph_context="pdf" %}</div>
+                {#  end private indivudals collections table #}
+            </section>
+        {% endif %}
     </div>
 {% endblock %}


### PR DESCRIPTION
L'encart explicatif du header a été changé avec la date de mise à jour de chaque données.
Le composant affichant la liste des déchets non dangereux marqués commé étant dangereux a été remontée.

De plus, correction d'un problème qui faisait qu'une page blanche état ajouté à la fin du PDF.



- [ ] Mettre à jour le change log
---

- [TRA-14587](https://favro.com/organization/ab14a4f0460a99a9d64d4945/37a331c647a38a191b2a1207?card=tra-14587)
- [TRA-14595](https://favro.com/organization/ab14a4f0460a99a9d64d4945/37a331c647a38a191b2a1207?card=tra-14595)
- [TRA-14590](https://favro.com/organization/ab14a4f0460a99a9d64d4945/37a331c647a38a191b2a1207?card=tra-14590)