### PR TITLE
Ajout des requêtes de révision pour les BSDASRI

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,10 @@ Les changements importants de Trackdéchets préparation inspection sont documen
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versioning inspiré de [Calendar Versioning](https://calver.org/).
 
+## 01/07/2024
+
+- Ajout des requêtes de révision pour les BSDASRI
+
 ## 23/06/2024
 
 - mise en place de l'Api

--- a/src/sheets/data_processing.py
+++ b/src/sheets/data_processing.py
@@ -23,6 +23,7 @@ from .database import (
     build_bsvhu_query,
     build_query_company,
     build_revised_bsda_query,
+    build_revised_bsdasri_query,
     build_revised_bsdd_query,
     get_agreement_data,
     get_gistrid_data,
@@ -132,7 +133,11 @@ bsds_config = [
         "bs_revised_data": build_revised_bsda_query,
         "bs_transporter_data": build_bsda_transporter_query,
     },
-    {"bsd_type": BSDASRI, "bs_data": build_bsdasri_query},
+    {
+        "bsd_type": BSDASRI,
+        "bs_data": build_bsdasri_query,
+        "bs_revised_data": build_revised_bsdasri_query,
+    },
     {
         "bsd_type": BSFF,
         "bs_data": build_bsff_query,

--- a/src/sheets/database.py
+++ b/src/sheets/database.py
@@ -30,6 +30,7 @@ from .queries import (
     sql_get_vhu_agrement_data,
     sql_revised_bsda_query_str,
     sql_revised_bsdd_query_str,
+    sql_revised_bsdasri_query_str,
 )
 
 wh_engine = create_engine(settings.WAREHOUSE_URL, pool_pre_ping=True)
@@ -201,6 +202,20 @@ def build_bsdasri_query(
         },
         date_columns=bsd_date_params,
     )
+
+
+def build_revised_bsdasri_query(
+    company_id: str,
+):
+    df = build_query(
+        sql_revised_bsdasri_query_str,
+        query_params={
+            "company_id": company_id,
+        },
+        date_columns=bsd_date_params,
+    )
+
+    return df
 
 
 def build_bsff_query(

--- a/src/sheets/graph_processors/html_components_processors.py
+++ b/src/sheets/graph_processors/html_components_processors.py
@@ -562,7 +562,6 @@ class BsdCanceledTableProcessor:
                     "emitter_company_siret",
                     "recipient_company_siret",
                     "waste_code",
-                    "waste_name",
                     "updated_at",
                     "comment",
                 ]
@@ -570,6 +569,10 @@ class BsdCanceledTableProcessor:
                 # Human-friendly id is stored in the readable_id column in the case of BSDDs
                 if "readable_id" in bs_data.columns:
                     columns_to_take.append("readable_id")
+
+                # BSDASRI does not have waste name
+                if "waste_name" in bs_data.columns:
+                    columns_to_take.append("waste_name")
 
                 temp_df = pd.merge(
                     cancellations,

--- a/src/sheets/queries.py
+++ b/src/sheets/queries.py
@@ -429,6 +429,18 @@ from trusted_zone_trackdechets.bsda_revision_request
 where authoring_company_id = :company_id
 """
 
+sql_revised_bsdasri_query_str = """
+select id,
+    bsdasri_id as bs_id,
+    status,
+    created_at,
+    updated_at,
+    comment,
+    is_canceled
+from trusted_zone_trackdechets.bsdasri_revision_request
+where authoring_company_id = :company_id
+"""
+
 sql_get_icpe_data = """
 select
     code_aiot,


### PR DESCRIPTION
De la même manière que les BSDD et BSDA, on affiche les révisions pour les BSDASRI ainsi que les BSDASRI annulés.

- [ ] Mettre à jour le change log
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/37a331c647a38a191b2a1207?card=tra-14566)
