### PR TITLE
Correction d'un bug sur le composant dédié aux entreprises de travaux

### DIFF
--- a/src/sheets/data_processing.py
+++ b/src/sheets/data_processing.py
@@ -547,6 +547,8 @@ class SheetProcessor:
             data_date_interval=data_date_interval,
         )
         self.computed.bsda_worker_stats_data = bsda_worker_stats.build()
+        if self.computed.bsda_worker_stats_data:
+            self.all_bsd_data_empty = False
 
         bsda_worker_quantities = BsdaWorkerQuantityProcessor(
             company_siret=self.siret,
@@ -563,6 +565,8 @@ class SheetProcessor:
             packagings_data_df=self.bsff_packagings_df,
         )
         self.computed.transporter_bordereaux_stats_data = transporter_bordereaux_stats.build()
+        if self.computed.transporter_bordereaux_stats_data:
+            self.all_bsd_data_empty = False
 
         followed_with_pnttd = FollowedWithPNTTDTableProcessor(
             company_siret=self.siret,

--- a/src/sheets/queries.py
+++ b/src/sheets/queries.py
@@ -255,6 +255,7 @@ where
         or destination_company_siret = :siret
         or transporter_company_siret = :siret
         or eco_organisme_siret = :siret
+        or worker_company_siret = :siret
     )
     and waste_code like '%*'
     -- to avoid pandas datetime overflow

--- a/src/sheets/templatetags/utils.py
+++ b/src/sheets/templatetags/utils.py
@@ -6,6 +6,6 @@ register = template.Library()
 @register.filter
 def number(nb):
     """Format a given number with thousands separators (spaces)"""
-    if not nb:
+    if (nb is None) or (nb == ""):
         return ""
     return str(nb).replace(" ", "&nbsp;")


### PR DESCRIPTION
Les données de transport BSDA n'étaient pas récupérées pour les entreprises de travaux ce qui entrainaient un bug. 
De plus il manquait des filtres dans la fonction de traitement des données du composant `BsdaWorkerStatsProcessor`.

- [ ] Mettre à jour le change log
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/37a331c647a38a191b2a1207?card=tra-14934)
