### PR TITLE
Correction de bugs sur les composants ICPE

### DIFF
--- a/src/sheets/graph_processors/html_components_processors.py
+++ b/src/sheets/graph_processors/html_components_processors.py
@@ -1544,7 +1544,7 @@ class WasteProcessingWithoutICPERubriqueProcessor:
     def __init__(
         self,
         company_siret: str,
-        bs_data_dfs: Dict[str, pd.DataFrame],
+        bs_data_dfs: Dict[str, pd.DataFrame | None],
         rndts_incoming_data: pd.DataFrame | None,
         icpe_data: pd.DataFrame | None,
         data_date_interval: tuple[datetime, datetime],
@@ -1567,45 +1567,49 @@ class WasteProcessingWithoutICPERubriqueProcessor:
         has_2760_2 = False
         icpe_data = self.icpe_data
 
-        if icpe_data is not None:
+        if (icpe_data is not None) and (len(icpe_data) > 0):
             has_2760_1 = len(icpe_data[(icpe_data["rubrique"] == "2760-1")]) > 0
             has_2760_2 = len(icpe_data[icpe_data["rubrique"].isin(["2760-2", "2760-2-a", "2760-2-b"])]) > 0
 
         if not has_2760_1:  # Means no authorization for ICPE 2760-1
             bs_2760_dfs = []
             bsdd_data = self.bs_data_dfs[BSDD]
-            bsdd_data_filtered = bsdd_data[
-                (bsdd_data["recipient_company_siret"] == self.siret)
-                & (bsdd_data["processing_operation_code"] == "D5")
-                & (bsdd_data["processed_at"].between(*self.data_date_interval))
-            ]
 
-            if len(bsdd_data_filtered):
-                bsdd_data_filtered["bs_type"] = "BSDD"
-                bs_2760_dfs.append(bsdd_data_filtered)
-
-            if not has_2760_2:  # Means no authorization for ICPE 2760-1 NEITHER 2760-2 (BSDA case)
-                bsda_data = self.bs_data_dfs[BSDA]
-                bsda_data_filtered = bsda_data[
-                    (bsda_data["recipient_company_siret"] == self.siret)
-                    & (bsda_data["processing_operation_code"] == "D5")
+            if (bsdd_data is not None) and (len(bsdd_data) > 0):
+                bsdd_data_filtered = bsdd_data[
+                    (bsdd_data["recipient_company_siret"] == self.siret)
+                    & (bsdd_data["processing_operation_code"] == "D5")
                     & (bsdd_data["processed_at"].between(*self.data_date_interval))
                 ]
-                if len(bsda_data_filtered) > 0:
-                    bsda_data_filtered["bs_type"] = "BSDA"
-                    bs_2760_dfs.append(bsda_data_filtered)
+
+                if len(bsdd_data_filtered):
+                    bsdd_data_filtered["bs_type"] = "BSDD"
+                    bs_2760_dfs.append(bsdd_data_filtered)
+
+                if not has_2760_2:  # Means no authorization for ICPE 2760-1 NEITHER 2760-2 (BSDA case)
+                    bsda_data = self.bs_data_dfs[BSDA]
+
+                    if (bsda_data is not None) and (len(bsda_data) > 0):
+                        bsda_data_filtered = bsda_data[
+                            (bsda_data["recipient_company_siret"] == self.siret)
+                            & (bsda_data["processing_operation_code"] == "D5")
+                            & (bsdd_data["processed_at"].between(*self.data_date_interval))
+                        ]
+                        if len(bsda_data_filtered) > 0:
+                            bsda_data_filtered["bs_type"] = "BSDA"
+                            bs_2760_dfs.append(bsda_data_filtered)
 
             if len(bs_2760_dfs) > 0:
-                bs_df = pd.concat(bs_2760_dfs)  # Creates the list of bordereaux
+                bs_df = pd.concat(bs_2760_dfs).reset_index(drop=True)  # Creates the list of bordereaux
                 self.preprocessed_data["dangerous"].append(
                     {
                         "missing_rubriques": "2760-1, 2760-2",
-                        "num_missing_rubrique": 2,
+                        "num_missing_rubriques": 2,
                         "found_processing_codes": "D5",
                         "num_found_processing_codes": 1,
                         "bs_list": bs_df,
                         "stats": {
-                            "total_bs": len(bs_df),  # Total number of bordereaux
+                            "total_bs": format_number_str(len(bs_df), 0),  # Total number of bordereaux
                             "total_quantity": format_number_str(
                                 bs_df["quantity_received"].sum(), 2
                             ),  # Total quantity processed
@@ -1657,7 +1661,7 @@ class WasteProcessingWithoutICPERubriqueProcessor:
 
             has_rubrique = False
             icpe_data = self.icpe_data
-            if icpe_data is not None:
+            if (icpe_data is not None) and (len(icpe_data) > 0):
                 has_rubrique = len(icpe_data[icpe_data["rubrique"] == rubrique]) > 0
 
             if not has_rubrique:
@@ -1675,7 +1679,7 @@ class WasteProcessingWithoutICPERubriqueProcessor:
                     found_processing_codes = bs_filtered_df["processing_operation_code"].unique()
                     self.preprocessed_data["dangerous"].append(
                         {
-                            "bs_list": bs_filtered_df,  # Creates the list of bordereaux
+                            "bs_list": bs_filtered_df.reset_index(drop=True),  # Creates the list of bordereaux
                             "missing_rubriques": rubrique,
                             "num_missing_rubriques": 1,
                             "found_processing_codes": ", ".join(found_processing_codes),
@@ -1768,8 +1772,8 @@ class WasteProcessingWithoutICPERubriqueProcessor:
                         "num_missing_rubriques": len(missing_rubriques),
                         "found_processing_codes": ", ".join(found_processing_codes),
                         "num_found_processing_codes": len(found_processing_codes),
-                        "statements_list": filtered_rndts_data_df.sort_values(
-                            "date_reception"
+                        "statements_list": filtered_rndts_data_df.sort_values("date_reception").reset_index(
+                            drop=True
                         ),  # Creates the list of statements
                         "stats": {
                             "total_statements": format_number_str(
@@ -1792,8 +1796,9 @@ class WasteProcessingWithoutICPERubriqueProcessor:
     ) -> pd.DataFrame:
         bs_dfs = []
         for bs_type, df in dfs_to_process:
-            if len(df) == 0:
+            if (df is None) or (len(df) == 0):
                 continue
+
             df_filtered = pd.DataFrame()
             if bs_type != BSFF:
                 df_filtered = df[

--- a/src/sheets/graph_processors/html_components_processors.py
+++ b/src/sheets/graph_processors/html_components_processors.py
@@ -1711,7 +1711,6 @@ class WasteProcessingWithoutICPERubriqueProcessor:
             {
                 "rubriques": ["2771"],
                 "processing_codes": [
-                    "D9",
                     "D10",
                 ],
             },
@@ -1744,8 +1743,13 @@ class WasteProcessingWithoutICPERubriqueProcessor:
             icpe_data_df = self.icpe_data
             missing_rubriques = rubriques
             if icpe_data_df is not None:
+                # Handle 2791 case that can have alinea
+                installation_rubriques = (
+                    icpe_data_df["rubrique"].str[:6].str.replace(pat="^2791.*", repl="2791").unique()
+                )
+
                 # To handle the case of rubriques with trailing "-a" or trailing "-b", we use only the 6 first characters
-                missing_rubriques = set(rubriques) - set(icpe_data_df["rubrique"].str[:6].unique())
+                missing_rubriques = set(rubriques) - set(installation_rubriques)
                 has_rubrique = len(missing_rubriques) == 0
 
             if has_rubrique:

--- a/src/sheets/graph_processors/plotly_components_processors.py
+++ b/src/sheets/graph_processors/plotly_components_processors.py
@@ -907,8 +907,8 @@ class ICPEAnnualItemProcessor:
         df = self.icpe_item_daily_data[["day_of_processing", "processed_quantity"]]
         df = df.sort_values("day_of_processing")
 
-        series = df.set_index("day_of_processing").squeeze()
-        final_df = series.resample("1d").max().fillna(0).reset_index()
+        df = df.set_index("day_of_processing")
+        final_df = df.resample("1d").max().fillna(0).reset_index()
         final_df["quantity_cumsum"] = final_df.groupby(final_df["day_of_processing"].dt.year).cumsum()
 
         self.preprocessed_df = final_df

--- a/src/sheets/graph_processors/plotly_components_processors.py
+++ b/src/sheets/graph_processors/plotly_components_processors.py
@@ -891,7 +891,7 @@ class ICPEAnnualItemProcessor:
 
     def __init__(
         self,
-        icpe_item_daily_data: pd.DataFrame,
+        icpe_item_daily_data: pd.DataFrame | None,
     ) -> None:
         self.icpe_item_daily_data = icpe_item_daily_data
 
@@ -916,6 +916,9 @@ class ICPEAnnualItemProcessor:
 
     def _check_data_empty(self) -> bool:
         if (self.preprocessed_df is None) or len(self.preprocessed_df) == 0:
+            return True
+
+        if self.preprocessed_df["processed_quantity"].sum() == 0:
             return True
 
         return False

--- a/src/sheets/tests/test_icpe_annual_item_processor.py
+++ b/src/sheets/tests/test_icpe_annual_item_processor.py
@@ -1,0 +1,182 @@
+import pytest
+import pandas as pd
+from pandas import Timestamp
+from datetime import datetime
+import plotly.graph_objects as go
+from ..graph_processors.plotly_components_processors import (
+    ICPEAnnualItemProcessor,
+)  # Import ICPEAnnualItemProcessor from the module where it is defined
+
+
+# Sample data fixture
+@pytest.fixture
+def sample_icpe_data():
+    data = {
+        "day_of_processing": [
+            datetime(2023, 1, 1),
+            datetime(2023, 1, 2),
+            datetime(2023, 1, 3),
+            datetime(2023, 1, 4),
+            datetime(2023, 1, 5),
+            datetime(2023, 1, 6),
+            datetime(2023, 1, 7),
+            datetime(2023, 1, 8),
+            datetime(2023, 1, 9),
+            datetime(2023, 1, 10),
+        ],
+        "processed_quantity": [10, 20, 15, 0, 5, 0, 25, 30, 0, 5],
+        "authorized_quantity": [50, 50, 50, 50, 50, 50, 50, 50, 50, 50],
+    }
+
+    return pd.DataFrame(data)
+
+
+def test_preprocess_data(sample_icpe_data):
+    processor = ICPEAnnualItemProcessor(icpe_item_daily_data=sample_icpe_data)
+
+    processor._preprocess_data()
+
+    preprocessed_df = processor.preprocessed_df
+
+    expected_output = pd.DataFrame(
+        {
+            "day_of_processing": [
+                Timestamp("2023-01-01 00:00:00"),
+                Timestamp("2023-01-02 00:00:00"),
+                Timestamp("2023-01-03 00:00:00"),
+                Timestamp("2023-01-04 00:00:00"),
+                Timestamp("2023-01-05 00:00:00"),
+                Timestamp("2023-01-06 00:00:00"),
+                Timestamp("2023-01-07 00:00:00"),
+                Timestamp("2023-01-08 00:00:00"),
+                Timestamp("2023-01-09 00:00:00"),
+                Timestamp("2023-01-10 00:00:00"),
+            ],
+            "processed_quantity": [10, 20, 15, 0, 5, 0, 25, 30, 0, 5],
+            "quantity_cumsum": [10, 30, 45, 45, 50, 50, 75, 105, 105, 110],
+        }
+    )
+
+    assert preprocessed_df.equals(expected_output)
+
+
+def test_only_one_data_point(sample_icpe_data):
+    data = sample_icpe_data.head(1)
+
+    processor = ICPEAnnualItemProcessor(icpe_item_daily_data=data)
+    processor._preprocess_data()
+
+    preprocessed_df = processor.preprocessed_df
+
+    expected_output = pd.DataFrame(
+        {
+            "day_of_processing": [
+                Timestamp("2023-01-01 00:00:00"),
+            ],
+            "processed_quantity": [
+                10,
+            ],
+            "quantity_cumsum": [
+                10,
+            ],
+        }
+    )
+
+    assert preprocessed_df.equals(expected_output)
+
+
+def test_empty_icpe_data():
+    processor = ICPEAnnualItemProcessor(icpe_item_daily_data=pd.DataFrame())
+
+    processor._preprocess_data()
+
+    assert processor._check_data_empty(), "Data should be considered empty when input DataFrame is empty."
+
+    processor = ICPEAnnualItemProcessor(icpe_item_daily_data=None)
+
+    processor._preprocess_data()
+
+    assert processor._check_data_empty(), "Data should be considered empty when input DataFrame is None."
+
+
+def test_correct_figure_creation(sample_icpe_data):
+    processor = ICPEAnnualItemProcessor(icpe_item_daily_data=sample_icpe_data)
+
+    processor._preprocess_data()
+    processor._create_figure()
+
+    figure = processor.figure
+
+    assert isinstance(figure, go.Figure), "The generated figure should be a Plotly Figure object."
+    assert len(figure.data) > 0, "Figure should contain at least one trace."
+
+
+def test_process_build(sample_icpe_data):
+    processor = ICPEAnnualItemProcessor(icpe_item_daily_data=sample_icpe_data)
+
+    result = processor.build()
+
+    assert isinstance(result, str), "Build method should return a JSON string representation of the figure."
+    assert len(result) > 0, "Build result should not be empty."
+
+
+def test_missing_columns():
+    data = {"day_of_processing": [datetime(2023, 1, 1)], "processed_quantity": [10]}
+
+    icpe_data_df = pd.DataFrame(data)
+
+    processor = ICPEAnnualItemProcessor(icpe_item_daily_data=icpe_data_df)
+
+    # Should raise a KeyError
+    with pytest.raises(KeyError):
+        processor._preprocess_data()
+
+
+def test_incorrect_data_format():
+    data = {
+        "day_of_processing": ["Not a datetime"],  # Incorrect date format
+        "processed_quantity": [10],
+        "authorized_quantity": [50],
+    }
+
+    icpe_data_df = pd.DataFrame(data)
+
+    processor = ICPEAnnualItemProcessor(icpe_item_daily_data=icpe_data_df)
+
+    # Should raise a TypeError due to type column not being Timestamp
+    with pytest.raises(TypeError):
+        processor._preprocess_data()
+
+
+def test_zero_processed_quantities():
+    data = {
+        "day_of_processing": [datetime(2023, 1, 1), datetime(2023, 1, 2), datetime(2023, 1, 3)],
+        "processed_quantity": [0, 0, 0],
+        "authorized_quantity": [50, 50, 50],
+    }
+
+    icpe_data_df = pd.DataFrame(data)
+
+    processor = ICPEAnnualItemProcessor(icpe_item_daily_data=icpe_data_df)
+
+    processor._preprocess_data()
+
+    assert (
+        processor._check_data_empty()
+    ), "Data should be considered empty when all rows have zero processed quantities."
+
+
+def test_only_nan_processed_quantities():
+    data = {
+        "day_of_processing": [datetime(2023, 1, 1), datetime(2023, 1, 2), datetime(2023, 1, 3)],
+        "processed_quantity": [float("nan"), float("nan"), float("nan")],
+        "authorized_quantity": [50, 50, 50],
+    }
+
+    icpe_data_df = pd.DataFrame(data)
+
+    processor = ICPEAnnualItemProcessor(icpe_item_daily_data=icpe_data_df)
+
+    processor._preprocess_data()
+
+    assert processor._check_data_empty(), "Data should be considered empty when all processed quantities are NaN."

--- a/src/sheets/tests/test_waste_processing_without_icpe_rubrique_processor.py
+++ b/src/sheets/tests/test_waste_processing_without_icpe_rubrique_processor.py
@@ -1,0 +1,248 @@
+import pytest
+import pandas as pd
+from pandas import Timestamp
+from datetime import datetime
+
+from sheets.constants import BSDA, BSDD
+
+from ..graph_processors.html_components_processors import WasteProcessingWithoutICPERubriqueProcessor
+
+
+# Example data for testing
+@pytest.fixture
+def sample_data():
+    # Sample data for ICPE data with different "rubriques"
+    icpe_data = pd.DataFrame({"rubrique": ["2770", "2791-1", "2718-1"]})
+
+    # Sample bordereau data for BSDD
+    bsdd_data = pd.DataFrame(
+        {
+            "recipient_company_siret": ["12345678900000", "12345678900000", "12345678900000"],
+            "processing_operation_code": ["D8", "D5", "D10"],
+            "processed_at": [
+                datetime(2023, 1, 1),
+                datetime(2023, 2, 2),
+                datetime(2023, 4, 3),
+            ],
+            "quantity_received": [12.5, 22, 30.1],
+        }
+    )
+
+    # Sample bordereau data for BSDA
+    bsda_data = pd.DataFrame(
+        {
+            "recipient_company_siret": ["12345678900000", "12345678900000"],
+            "processing_operation_code": ["D5", "R2"],
+            "processed_at": [
+                datetime(2023, 2, 2),
+                datetime(2023, 4, 3),
+            ],
+            "quantity_received": [5, 15],
+        }
+    )
+
+    # Sample RNDTS incoming data
+    rndts_incoming_data = pd.DataFrame(
+        {
+            "numero_identification_declarant": ["12345678900000", "12345678900000"],
+            "date_reception": [
+                datetime(2023, 1, 1),
+                datetime(2023, 2, 2),
+            ],
+            "code_traitement": ["D5", "R1"],
+            "quantite": [30, 20],
+        }
+    )
+
+    bs_data_dfs = {BSDD: bsdd_data, BSDA: bsda_data}
+    data_date_interval = (
+        datetime(2023, 1, 1),
+        datetime(2023, 4, 30),
+    )
+
+    return bs_data_dfs, rndts_incoming_data, icpe_data, data_date_interval
+
+
+def test_initialization(sample_data):
+    """Test that the processor initializes with correct parameters."""
+
+    bs_data_dfs, rndts_incoming_data, icpe_data, data_date_interval = sample_data
+    processor = WasteProcessingWithoutICPERubriqueProcessor(
+        company_siret="12345678900000",
+        bs_data_dfs=bs_data_dfs,
+        rndts_incoming_data=rndts_incoming_data,
+        icpe_data=icpe_data,
+        data_date_interval=data_date_interval,
+        packagings_data_df=None,
+    )
+    assert processor.siret == "12345678900000"
+    assert processor.data_date_interval is not None
+    assert isinstance(processor.bs_data_dfs, dict)
+    assert isinstance(processor.icpe_data, pd.DataFrame)
+
+
+def test_preprocess_data_multi_rubriques(sample_data):
+    """Test that multiple rubrique processing works correctly."""
+    bs_data_dfs, rndts_incoming_data, icpe_data, data_date_interval = sample_data
+    processor = WasteProcessingWithoutICPERubriqueProcessor(
+        company_siret="12345678900000",
+        bs_data_dfs=bs_data_dfs,
+        rndts_incoming_data=rndts_incoming_data,
+        icpe_data=icpe_data,
+        data_date_interval=data_date_interval,
+        packagings_data_df=None,
+    )
+
+    processor._preprocess_data_multi_rubriques()
+    preprocessed_data = processor.preprocessed_data["dangerous"]
+    assert len(preprocessed_data) == 1
+
+    item = preprocessed_data[0]
+    expected_output = {
+        "missing_rubriques": "2760-1, 2760-2",
+        "num_missing_rubriques": 2,
+        "found_processing_codes": "D5",
+        "num_found_processing_codes": 1,
+        "bs_list": pd.DataFrame(
+            {
+                "recipient_company_siret": ["12345678900000", "12345678900000"],
+                "processing_operation_code": ["D5", "D5"],
+                "processed_at": [Timestamp("2023-02-02 00:00:00"), Timestamp("2023-02-02 00:00:00")],
+                "quantity_received": [22.0, 5.0],
+                "bs_type": ["BSDD", "BSDA"],
+            }
+        ),
+        "stats": {"total_bs": "2", "total_quantity": "27"},
+    }
+
+    assert item.keys() == expected_output.keys()
+
+    for key in item.keys():
+        if key == "bs_list":
+            # Dataframes equality test
+            assert item[key].equals(expected_output[key])
+        else:
+            assert item[key] == expected_output[key]
+
+
+def test_preprocess_data_single_rubrique(sample_data):
+    """Test that single rubrique processing works correctly."""
+    bs_data_dfs, rndts_incoming_data, icpe_data, data_date_interval = sample_data
+    processor = WasteProcessingWithoutICPERubriqueProcessor(
+        company_siret="12345678900000",
+        bs_data_dfs=bs_data_dfs,
+        rndts_incoming_data=rndts_incoming_data,
+        icpe_data=icpe_data,
+        data_date_interval=data_date_interval,
+        packagings_data_df=None,
+    )
+
+    processor._preprocess_data_single_rubrique()
+    dangerous_data = processor.preprocessed_data["dangerous"]
+    assert len(dangerous_data) == 1
+
+    item = dangerous_data[0]
+
+    expected_output = {
+        "missing_rubriques": "2790",
+        "num_missing_rubriques": 1,
+        "found_processing_codes": "R2, D8",
+        "num_found_processing_codes": 2,
+        "bs_list": pd.DataFrame(
+            {
+                "recipient_company_siret": ["12345678900000", "12345678900000"],
+                "processing_operation_code": ["R2", "D8"],
+                "processed_at": [Timestamp("2023-04-03 00:00:00"), Timestamp("2023-01-01 00:00:00")],
+                "quantity_received": [15.0, 12.5],
+                "bs_type": ["BSDA", "BSDD"],
+            }
+        ),
+        "stats": {"total_bs": "2", "total_quantity": "27.5"},
+    }
+
+    assert item.keys() == expected_output.keys()
+    for key in item.keys():
+        if key == "bs_list":
+            # Dataframes equality test
+            assert item[key].equals(expected_output[key])
+        else:
+            assert item[key] == expected_output[key]
+
+
+def test_preprocess_non_dangerous_rubriques(sample_data):
+    """Test that non-dangerous rubrique processing works correctly."""
+    bs_data_dfs, rndts_incoming_data, icpe_data, data_date_interval = sample_data
+    processor = WasteProcessingWithoutICPERubriqueProcessor(
+        company_siret="12345678900000",
+        bs_data_dfs=bs_data_dfs,
+        rndts_incoming_data=rndts_incoming_data,
+        icpe_data=icpe_data,
+        data_date_interval=data_date_interval,
+        packagings_data_df=None,
+    )
+    processor._preprocess_non_dangerous_rubriques()
+    non_dangerous_data = processor.preprocessed_data["non_dangerous"]
+
+    assert len(non_dangerous_data) == 2
+
+    expected_output = [
+        {
+            "missing_rubriques": "2760-2",
+            "num_missing_rubriques": 1,
+            "found_processing_codes": "D5",
+            "num_found_processing_codes": 1,
+            "statements_list": pd.DataFrame(
+                {
+                    "numero_identification_declarant": ["12345678900000"],
+                    "date_reception": [Timestamp("2023-01-01 00:00:00")],
+                    "code_traitement": ["D5"],
+                    "quantite": [30],
+                }
+            ),
+            "stats": {"total_statements": "1", "total_quantity": "30"},
+        },
+        {
+            "missing_rubriques": "2771",
+            "num_missing_rubriques": 1,
+            "found_processing_codes": "R1",
+            "num_found_processing_codes": 1,
+            "statements_list": pd.DataFrame(
+                {
+                    "numero_identification_declarant": ["12345678900000"],
+                    "date_reception": [Timestamp("2023-02-02 00:00:00")],
+                    "code_traitement": ["R1"],
+                    "quantite": [20],
+                }
+            ),
+            "stats": {"total_statements": "1", "total_quantity": "20"},
+        },
+    ]
+
+    for item, expected_item in zip(non_dangerous_data, expected_output):
+        assert item.keys() == expected_item.keys()
+
+        for key in item.keys():
+            if key == "statements_list":
+                # Dataframes equality test
+                assert item[key].equals(expected_item[key])
+            else:
+                assert item[key] == expected_item[key]
+
+
+def test_check_data_empty():
+    """Test that the data check function works correctly."""
+
+    processor = WasteProcessingWithoutICPERubriqueProcessor(
+        company_siret="12345678900000",
+        bs_data_dfs={BSDD: None, BSDA: pd.DataFrame()},
+        rndts_incoming_data=None,
+        icpe_data=None,
+        data_date_interval=(
+            datetime(2023, 1, 1),
+            datetime(2023, 4, 30),
+        ),
+        packagings_data_df=None,
+    )
+    # Trigger data preprocessing
+    processor._preprocess_data()
+    assert processor._check_data_empty() is True


### PR DESCRIPTION
Un bug a été résolu sur le composant `ICPEAnnualItemProcssor` lorsque l'établissement avait un seul point de donnée sur une rubrique particulière.
La logique et la robustesse du traitement de données du composant `WasteProcessingWithoutICPERubriqueProcessor` a été revue également.

Enin des tests ont été ajoutés pour ces deux composants.

- [ ] Mettre à jour le change log
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/37a331c647a38a191b2a1207?card=tra-15027)
