### PR TITLE
Correction d'un bug dans IncineratorOutgoingWasteProcessor

### DIFF
--- a/src/sheets/graph_processors/html_components_processors.py
+++ b/src/sheets/graph_processors/html_components_processors.py
@@ -2674,21 +2674,24 @@ class IncineratorOutgoingWasteProcessor:
             if len(df) > 0:
                 dfs_to_concat.append(df)
 
-            concat_df = pd.concat(dfs_to_concat)
+            if len(dfs_to_concat) > 0:
+                concat_df = pd.concat(dfs_to_concat)
 
-            aggregated_data_df = (
-                concat_df.groupby(
-                    ["waste_code", "recipient_company_siret", "processing_operation_code"], as_index=False
+                aggregated_data_df = (
+                    concat_df.groupby(
+                        ["waste_code", "recipient_company_siret", "processing_operation_code"], as_index=False
+                    )
+                    .aggregate(
+                        quantity=pd.NamedAgg(column="quantity_received", aggfunc="sum"),
+                        waste_name=pd.NamedAgg(column="waste_name", aggfunc="max"),
+                    )
+                    .sort_values(
+                        by=["waste_code", "recipient_company_siret", "quantity"], ascending=[True, True, False]
+                    )
                 )
-                .aggregate(
-                    quantity=pd.NamedAgg(column="quantity_received", aggfunc="sum"),
-                    waste_name=pd.NamedAgg(column="waste_name", aggfunc="max"),
-                )
-                .sort_values(by=["waste_code", "recipient_company_siret", "quantity"], ascending=[True, True, False])
-            )
 
-            if len(aggregated_data_df) > 0:
-                self.preprocessed_data["dangerous"] = aggregated_data_df
+                if len(aggregated_data_df) > 0:
+                    self.preprocessed_data["dangerous"] = aggregated_data_df
 
     def _preprocess_rndts_statements_data(self) -> None:
         """Preprocess raw RNDTS statements data to prepare it to be displayed."""

--- a/src/sheets/graph_processors/plotly_components_processors.py
+++ b/src/sheets/graph_processors/plotly_components_processors.py
@@ -2647,7 +2647,9 @@ class RNDTSTransporterQuantitiesGraphProcessor:
                     self.transported_quantities_stats[key][unit] = df_by_month
 
     def _check_data_empty(self) -> bool:
-        if all((e is None) or (len(e) == 0) for e in self.transported_quantities_stats.values()):
+        if all(
+            (ee is None) or (len(ee) == 0) for e in self.transported_quantities_stats.values() for ee in e.values()
+        ):
             return True
 
         return False

--- a/src/sheets/tests/constants.py
+++ b/src/sheets/tests/constants.py
@@ -1,4 +1,3 @@
 from pathlib import Path
 
-
 EXPECTED_FILES_PATH = Path(__file__).parent.resolve() / "expected"

--- a/src/sheets/tests/constants.py
+++ b/src/sheets/tests/constants.py
@@ -1,0 +1,4 @@
+from pathlib import Path
+
+
+EXPECTED_FILES_PATH = Path(__file__).parent.resolve() / "expected"

--- a/src/sheets/tests/expected/incinerator_outgoing_waste_build_data_expected.json
+++ b/src/sheets/tests/expected/incinerator_outgoing_waste_build_data_expected.json
@@ -1,0 +1,43 @@
+{
+  "dangerous": [
+    {
+      "waste_code": "01 01 01*",
+      "waste_name": "D\\u00e9chet A",
+      "destination_company_siret": "43210987654321",
+      "processing_opration": "D10",
+      "quantity": "30"
+    },
+    {
+      "waste_code": "01 01 03*",
+      "waste_name": "D\\u00e9chet B",
+      "destination_company_siret": "87654321098765",
+      "processing_opration": "D5",
+      "quantity": "9.3"
+    },
+    {
+      "waste_code": "02 01 01*",
+      "waste_name": "D\\u00e9chet C",
+      "destination_company_siret": "87654321098765",
+      "processing_opration": "D10",
+      "quantity": "12.5"
+    }
+  ],
+  "non_dangerous": [
+    {
+      "waste_code": "02 01 03",
+      "waste_name": "D\\u00e9chet CC",
+      "destination_company_siret": "56789012345678",
+      "unit": "T",
+      "processing_opration": "D5",
+      "quantity": "35"
+    },
+    {
+      "waste_code": "04 01 01",
+      "waste_name": "D\\u00e9chet AA",
+      "destination_company_siret": "98765432109876",
+      "unit": "M3",
+      "processing_opration": "R1",
+      "quantity": "15"
+    }
+  ]
+}

--- a/src/sheets/tests/expected/incinerator_outgoing_waste_build_data_expected.json
+++ b/src/sheets/tests/expected/incinerator_outgoing_waste_build_data_expected.json
@@ -2,21 +2,21 @@
   "dangerous": [
     {
       "waste_code": "01 01 01*",
-      "waste_name": "D\\u00e9chet A",
+      "waste_name": "Déchet A",
       "destination_company_siret": "43210987654321",
       "processing_opration": "D10",
       "quantity": "30"
     },
     {
       "waste_code": "01 01 03*",
-      "waste_name": "D\\u00e9chet B",
+      "waste_name": "Déchet B",
       "destination_company_siret": "87654321098765",
       "processing_opration": "D5",
       "quantity": "9.3"
     },
     {
       "waste_code": "02 01 01*",
-      "waste_name": "D\\u00e9chet C",
+      "waste_name": "Déchet C",
       "destination_company_siret": "87654321098765",
       "processing_opration": "D10",
       "quantity": "12.5"
@@ -25,7 +25,7 @@
   "non_dangerous": [
     {
       "waste_code": "02 01 03",
-      "waste_name": "D\\u00e9chet CC",
+      "waste_name": "Déchet CC",
       "destination_company_siret": "56789012345678",
       "unit": "T",
       "processing_opration": "D5",
@@ -33,7 +33,7 @@
     },
     {
       "waste_code": "04 01 01",
-      "waste_name": "D\\u00e9chet AA",
+      "waste_name": "Déchet AA",
       "destination_company_siret": "98765432109876",
       "unit": "M3",
       "processing_opration": "R1",

--- a/src/sheets/tests/test_incinerator_outgoing_waste_processor.py
+++ b/src/sheets/tests/test_incinerator_outgoing_waste_processor.py
@@ -243,6 +243,8 @@ def test_build_with_data(
     assert len(result["dangerous"]) > 0, "No dangerous waste data in result"
     assert len(result["non_dangerous"]) > 0, "No non-dangerous waste data in result"
 
-    expected_data = json.load((EXPECTED_FILES_PATH / "incinerator_outgoing_waste_build_data_expected.json").open())
+    expected_data = json.load(
+        (EXPECTED_FILES_PATH / "incinerator_outgoing_waste_build_data_expected.json").open(encoding="utf-8")
+    )
 
     assert result == expected_data

--- a/src/sheets/tests/test_incinerator_outgoing_waste_processor.py
+++ b/src/sheets/tests/test_incinerator_outgoing_waste_processor.py
@@ -1,15 +1,13 @@
-from datetime import datetime
 import json
+from datetime import datetime
 
 import pandas as pd
 import pytest
 
 from sheets.constants import BSDA, BSDD
-from .constants import EXPECTED_FILES_PATH
 
-from ..graph_processors.html_components_processors import (
-    IncineratorOutgoingWasteProcessor,
-)
+from ..graph_processors.html_components_processors import IncineratorOutgoingWasteProcessor
+from .constants import EXPECTED_FILES_PATH
 
 
 @pytest.fixture

--- a/src/sheets/tests/test_incinerator_outgoing_waste_processor.py
+++ b/src/sheets/tests/test_incinerator_outgoing_waste_processor.py
@@ -243,6 +243,6 @@ def test_build_with_data(
     assert len(result["dangerous"]) > 0, "No dangerous waste data in result"
     assert len(result["non_dangerous"]) > 0, "No non-dangerous waste data in result"
 
-    expected_data = json.load(EXPECTED_FILES_PATH / "incinerator_outgoing_waste_build_data_expected.json")
+    expected_data = json.load((EXPECTED_FILES_PATH / "incinerator_outgoing_waste_build_data_expected.json").open())
 
     assert result == expected_data

--- a/src/sheets/tests/test_incinerator_outgoing_waste_processor.py
+++ b/src/sheets/tests/test_incinerator_outgoing_waste_processor.py
@@ -1,0 +1,250 @@
+from datetime import datetime
+import json
+
+import pandas as pd
+import pytest
+
+from sheets.constants import BSDA, BSDD
+from .constants import EXPECTED_FILES_PATH
+
+from ..graph_processors.html_components_processors import (
+    IncineratorOutgoingWasteProcessor,
+)
+
+
+@pytest.fixture
+def sample_data() -> dict:
+    bs_data_dfs = {
+        BSDD: pd.DataFrame(
+            {
+                "id": [1, 2, 3, 4],
+                "emitter_company_siret": ["12345678901234", "12345678901234", "98765432109876", "98765432109876"],
+                "recipient_company_siret": ["43210987654321", "43210987654321", "12345678901234", "87654321098769"],
+                "received_at": [
+                    datetime(2023, 1, 11),
+                    datetime(2023, 3, 18),
+                    datetime(2023, 5, 24),
+                    datetime(2023, 5, 21),
+                ],
+                "waste_code": ["01 01 01*", "01 01 01*", "01 01 03*", "01 01 03*"],
+                "waste_name": ["Déchet A", "Déchet A", "Déchet B", "Déchet B"],
+                "processing_operation_code": ["D10", "D10", "D5", "R1"],
+                "quantity_received": [10, 20, 30, 19],
+            }
+        ),
+        BSDA: pd.DataFrame(
+            {
+                "id": [4, 5, 6, 1],
+                "emitter_company_siret": ["12345678901234", "98765432109876", "12345678901234", "87654321098765"],
+                "recipient_company_siret": ["87654321098765", "12345678901234", "87654321098765", "97654321098765"],
+                "received_at": [
+                    datetime(2023, 2, 1),
+                    datetime(2023, 4, 20),
+                    datetime(2023, 6, 10),
+                    datetime(2023, 7, 14),
+                ],
+                "waste_code": ["02 01 01*", "02 01 02*", "01 01 03*", "02 01 01*"],
+                "waste_name": ["Déchet C", "Déchet D", "Déchet B", "Déchet C"],
+                "processing_operation_code": ["D10", "D10", "D5", "R1"],
+                "quantity_received": [12.5, 32, 9.3, 10],
+            }
+        ),
+    }
+
+    transporters_data_df = {
+        BSDD: pd.DataFrame(
+            {
+                "bs_id": [1, 2, 3, 4],
+                "transporter_company_siret": ["56789012345678", "56789012345678", "97654321098765", "12345678901234"],
+                "sent_at": [
+                    datetime(2023, 1, 10),
+                    datetime(2023, 3, 15),
+                    datetime(2023, 5, 20),
+                    datetime(2023, 5, 20),
+                ],
+                "quantity_received": [10, 20, 30, 19],
+            }
+        ),
+        BSDA: pd.DataFrame(
+            {
+                "bs_id": [4, 5, 6, 1],
+                "transporter_company_siret": ["56789012345678", "56789012345678", "97654321098765", "12345678901234"],
+                "sent_at": [
+                    datetime(2023, 1, 10),
+                    datetime(2023, 3, 15),
+                    datetime(2023, 5, 20),
+                    datetime(2023, 5, 20),
+                ],
+                "quantity_received": [12.5, 32, 9.3, 10],
+            }
+        ),
+    }
+
+    rndts_data_df = {
+        "ndw_outgoing": pd.DataFrame(
+            {
+                "numero_identification_declarant": ["12345678901234", "98765432109876", "12345678901234"],
+                "destinataire_numero_identification": ["98765432109876", "98765432109876", "56789012345678"],
+                "date_expedition": [datetime(2023, 2, 1), datetime(2023, 4, 20), datetime(2023, 6, 10)],
+                "quantite": [15, 25, 35],
+                "code_dechet": ["04 01 01", "04 01 02", "02 01 03"],
+                "denomination_usuelle": ["Déchet AA", "Déchet BB", "Déchet CC"],
+                "unite": ["M3", "T", "T"],
+                "numeros_indentification_transporteurs": [
+                    ["98765432109876"],
+                    ["12345678901234", "98765432109876"],
+                    ["98765432109876"],
+                ],
+                "code_traitement": ["R1", "R2", "D5"],
+            }
+        )
+    }
+
+    icpe_data_df = pd.DataFrame({"rubrique": ["2770", "2771"]})
+
+    return {
+        "bs_data": bs_data_dfs,
+        "transporters_data": transporters_data_df,
+        "rndts_data": rndts_data_df,
+        "icpe_data": icpe_data_df,
+    }
+
+
+@pytest.fixture
+def sample_data_date_interval():
+    """Sample data date interval for filtering"""
+    return (datetime(2023, 1, 1), datetime(2023, 6, 30))
+
+
+def test_preprocess_bs_data(sample_data, sample_data_date_interval):
+    """Test preprocessing of BS data for dangerous waste"""
+    processor = IncineratorOutgoingWasteProcessor(
+        company_siret="12345678901234",
+        bs_data_dfs=sample_data["bs_data"],
+        transporters_data_df=sample_data["transporters_data"],
+        icpe_data=sample_data["icpe_data"],
+        rndts_outgoing_data=None,  # Testing only BS data
+        data_date_interval=sample_data_date_interval,
+    )
+    processor._preprocess_bs_data()
+
+    preprocessed_data = processor.preprocessed_data["dangerous"]
+    assert len(preprocessed_data) == 3
+
+    expected_data = pd.DataFrame(
+        [
+            {
+                "waste_code": "01 01 01*",
+                "recipient_company_siret": "43210987654321",
+                "processing_operation_code": "D10",
+                "quantity": 30.0,
+                "waste_name": "Déchet A",
+            },
+            {
+                "waste_code": "01 01 03*",
+                "recipient_company_siret": "87654321098765",
+                "processing_operation_code": "D5",
+                "quantity": 9.3,
+                "waste_name": "Déchet B",
+            },
+            {
+                "waste_code": "02 01 01*",
+                "recipient_company_siret": "87654321098765",
+                "processing_operation_code": "D10",
+                "quantity": 12.5,
+                "waste_name": "Déchet C",
+            },
+        ]
+    )
+
+    assert preprocessed_data.equals(expected_data)
+
+
+def test_preprocess_rndts_statements_data(sample_data, sample_data_date_interval):
+    """Test preprocessing of RNDTS data for non-dangerous waste"""
+    processor = IncineratorOutgoingWasteProcessor(
+        company_siret="12345678901234",
+        bs_data_dfs={},
+        transporters_data_df={},
+        icpe_data=sample_data["icpe_data"],
+        rndts_outgoing_data=sample_data["rndts_data"]["ndw_outgoing"],
+        data_date_interval=sample_data_date_interval,
+    )
+    processor._preprocess_rndts_statements_data()
+
+    preprocessed_data = processor.preprocessed_data["non_dangerous"]
+    assert len(preprocessed_data) == 2
+
+    expected_data = pd.DataFrame(
+        [
+            {
+                "code_dechet": "02 01 03",
+                "destinataire_numero_identification": "56789012345678",
+                "code_traitement": "D5",
+                "unite": "T",
+                "quantite": 35,
+                "denomination_usuelle": "Déchet CC",
+            },
+            {
+                "code_dechet": "04 01 01",
+                "destinataire_numero_identification": "98765432109876",
+                "code_traitement": "R1",
+                "unite": "M3",
+                "quantite": 15,
+                "denomination_usuelle": "Déchet AA",
+            },
+        ]
+    )
+
+    assert preprocessed_data.equals(expected_data)
+
+
+def test_is_incinerator(sample_data):
+    """Test the incinerator detection method"""
+    processor = IncineratorOutgoingWasteProcessor(
+        company_siret="12345678901234",
+        bs_data_dfs={},
+        transporters_data_df={},
+        icpe_data=sample_data["icpe_data"],
+        rndts_outgoing_data=None,
+        data_date_interval=(datetime(2024, 1, 1), datetime(2024, 12, 31)),
+    )
+    assert processor.is_incinerator(dangerous_waste=True), "Incinerator detection failed for dangerous waste"
+    assert processor.is_incinerator(dangerous_waste=False), "Incinerator detection failed for non-dangerous waste"
+
+
+def test_build_with_no_data(sample_data):
+    """Test build method when no data is available"""
+    processor = IncineratorOutgoingWasteProcessor(
+        company_siret="87654321098765",
+        bs_data_dfs={},
+        transporters_data_df={},
+        icpe_data=sample_data["icpe_data"],
+        rndts_outgoing_data=None,
+        data_date_interval=(datetime(2024, 1, 1), datetime(2024, 12, 31)),
+    )
+    result = processor.build()
+    assert result == {}, "Expected empty result when no data is available"
+    assert processor._check_data_empty()
+
+
+def test_build_with_data(
+    sample_data,
+    sample_data_date_interval,
+):
+    """Test build method with both BS and RNDTS data"""
+    processor = IncineratorOutgoingWasteProcessor(
+        company_siret="12345678901234",
+        bs_data_dfs=sample_data["bs_data"],
+        transporters_data_df=sample_data["transporters_data"],
+        icpe_data=sample_data["icpe_data"],
+        rndts_outgoing_data=sample_data["rndts_data"]["ndw_outgoing"],  # Testing only BS data
+        data_date_interval=sample_data_date_interval,
+    )
+    result = processor.build()
+    assert len(result["dangerous"]) > 0, "No dangerous waste data in result"
+    assert len(result["non_dangerous"]) > 0, "No non-dangerous waste data in result"
+
+    expected_data = json.load(EXPECTED_FILES_PATH / "incinerator_outgoing_waste_build_data_expected.json")
+
+    assert result == expected_data

--- a/src/sheets/tests/test_waste_flows_table_processor.py
+++ b/src/sheets/tests/test_waste_flows_table_processor.py
@@ -6,12 +6,11 @@ import pytest
 
 from sheets.constants import BSDA, BSDD, BSFF
 from sheets.data_extract import load_waste_code_data
+from .constants import EXPECTED_FILES_PATH
 
 from ..graph_processors.html_components_processors import (
     WasteFlowsTableProcessor,
 )  # Adjust the import to your actual module
-
-EXPECTED_FILES_PATH = Path(__file__).parent.resolve() / "expected"
 
 
 @pytest.fixture

--- a/src/sheets/tests/test_waste_flows_table_processor.py
+++ b/src/sheets/tests/test_waste_flows_table_processor.py
@@ -6,11 +6,11 @@ import pytest
 
 from sheets.constants import BSDA, BSDD, BSFF
 from sheets.data_extract import load_waste_code_data
-from .constants import EXPECTED_FILES_PATH
 
 from ..graph_processors.html_components_processors import (
     WasteFlowsTableProcessor,
 )  # Adjust the import to your actual module
+from .constants import EXPECTED_FILES_PATH
 
 
 @pytest.fixture

--- a/src/sheets/tests/test_waste_flows_table_processor.py
+++ b/src/sheets/tests/test_waste_flows_table_processor.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from pathlib import Path
 
 import pandas as pd
 import pytest


### PR DESCRIPTION
Le processor plantait en cas d'incinérateur sans aucune donnée après application des filtres.
Correction d'une erreur de logique qui rendait la mauvaise valeur pour `_check_data_empty` du `IncineratorOutgoingWasteProcessor`.
Ajout de tests pour `IncineratorOutgoingWasteProcessor`.


- [ ] Mettre à jour le change log
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/37a331c647a38a191b2a1207?card=tra-15266)
