### PR TITLE
Corrige un problème sur les révisions de bordereaux

### DIFF
--- a/src/sheets/data_processing.py
+++ b/src/sheets/data_processing.py
@@ -204,6 +204,7 @@ class SheetProcessor:
     def _extract_company_data(self):
         company_data_df = build_query_company(siret=self.siret, date_params=["created_at"])
         self.company_data = company_data_df
+        self.company_id = company_data_df["id"].item()
 
         self.receipts_agreements_data = get_agreement_data(company_data_df)
         self.linked_companies_data = get_linked_companies_data(self.siret)


### PR DESCRIPTION
Les révisions n'étaient pas affichées car l'ID de l'établissement n'était pas peuplé avant la requête sur la table des révisions.

- [ ] Mettre à jour le change log
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/37a331c647a38a191b2a1207?card=tra-15341)
