### PR TITLE
Use new controlbsd query

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,3 +90,4 @@ jobs:
           AWS_S3_ENDPOINT_URL: "https://s3.fr-par.scw.cloud"
           AWS_ACCESS_KEY_ID: "XYZ"
           AWS_SECRET_ACCESS_KEY: "xyz2"
+          USE_CONTROL_BSDS_QUERY: true

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,10 @@ Les changements importants de Trackdéchets préparation inspection sont documen
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versioning inspiré de [Calendar Versioning](https://calver.org/).
 
+## 21/10/2024
+
+- utilisation de la query controlBds pour le contrôle routier
+
 ## 03/10/2024
 
 - Recherche de BSD par identifiants

--- a/src/.env.dist
+++ b/src/.env.dist
@@ -56,4 +56,7 @@ AWS_S3_ENDPOINT_URL = "https://thebucket.s3.fr-par.scw.cloud"
 AWS_ACCESS_KEY_ID = "AWS1234"
 AWS_SECRET_ACCESS_KEY = "xyz-sdf-233-jhg'
 
-# Disable menu entry for beta
+# Disable siret check for local testing - only available in dev environnment
+SKIP_ROAD_CONTROL_SIRET_CHECK=True|False
+# use dedicated query
+USE_CONTROL_BSDS_QUERY=True|False

--- a/src/config/settings/base.py
+++ b/src/config/settings/base.py
@@ -285,3 +285,6 @@ STORAGES = {
         "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
     },
 }
+
+SKIP_ROAD_CONTROL_SIRET_CHECK = False
+USE_CONTROL_BSDS_QUERY = env.bool("USE_CONTROL_BSDS_QUERY")

--- a/src/config/settings/dev.py
+++ b/src/config/settings/dev.py
@@ -1,4 +1,5 @@
 from .base import *  # noqa
+from .base import env
 
 SECRET_KEY = "xyzabcdefghu"
 
@@ -43,3 +44,6 @@ LOGGING = {
         "level": "INFO",
     },
 }
+
+
+SKIP_ROAD_CONTROL_SIRET_CHECK = env("SKIP_ROAD_CONTROL_SIRET_CHECK")

--- a/src/roadcontrol/constants.py
+++ b/src/roadcontrol/constants.py
@@ -54,3 +54,9 @@ class BsdStatus:
     TEMP_STORED = "TEMP_STORED"
     # Déchet accepté par le site d'entreposage ou reconditionnement
     TEMP_STORER_ACCEPTED = "TEMP_STORER_ACCEPTED"
+    #  Une partie des contenants a été refusée, l'autre partie acceptée. Les contenants acceptés n'ont pas encore été traités.
+    PARTIALLY_REFUSED = "PARTIALLY_REFUSED"
+
+    INTERMEDIATELY_PROCESSED = "INTERMEDIATELY_PROCESSED"
+    # Signé par l'entreprise de travaux
+    SIGNED_BY_WORKER = "SIGNED_BY_WORKER"

--- a/src/roadcontrol/converters.py
+++ b/src/roadcontrol/converters.py
@@ -184,7 +184,7 @@ def bsda_to_bsd_display(bsda) -> BsdDisplay:
         "id": deep_get(bsda, "id"),
         "status": deep_get(bsda, "bsdaStatus"),
         "readable_id": deep_get(bsda, "id"),
-        "updated_at": format_date(deep_get(bsda, "updatedAt")),
+        "updated_at": format_date(deep_get(bsda, "bsdaUpdatedAt")),
         "adr": deep_get(bsda, "waste.adr"),
         "waste_details": {
             "code": waste_code,

--- a/src/roadcontrol/converters.py
+++ b/src/roadcontrol/converters.py
@@ -152,7 +152,7 @@ def bsdasri_to_bsd_display(bsdasri) -> BsdDisplay:
         "id": deep_get(bsdasri, "id"),
         "status": deep_get(bsdasri, "bsdasriStatus"),
         "readable_id": deep_get(bsdasri, "id"),
-        "updated_at": format_date(deep_get(bsdasri, "updatedAt")),
+        "updated_at": format_date(deep_get(bsdasri, "bsdasriUpdatedAt")),
         "adr": deep_get(bsdasri, "bsdasriWaste.adr"),
         "waste_details": {
             "code": waste_code,

--- a/src/roadcontrol/forms.py
+++ b/src/roadcontrol/forms.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.forms import CharField, Form, HiddenInput, ValidationError
 from sqlalchemy.sql import text
 
@@ -40,7 +41,7 @@ class RoadControlSearchForm(Form):
         with wh_engine.connect() as con:
             companies = con.execute(prepared_query, siret=siret).all()
 
-        if not companies:
+        if not companies and not settings.SKIP_ROAD_CONTROL_SIRET_CHECK:
             raise ValidationError("Établissement non inscrit sur Trackdéchets.")
         return siret
 

--- a/src/roadcontrol/td_requests.py
+++ b/src/roadcontrol/td_requests.py
@@ -504,7 +504,6 @@ query ControlBsds {
         ... on Bsdasri {
           ...BsdasriFragment
         }
-
         ... on Bsda {
           ...BsdaFragment
         }

--- a/src/roadcontrol/templatetags/road_control_tags.py
+++ b/src/roadcontrol/templatetags/road_control_tags.py
@@ -84,6 +84,7 @@ EN_ATTENTE_TRAITEMENT = "En attente de traitement"
 
 @register.inclusion_tag("roadcontrol/tags/status_badge.html")
 def status_badge(status: str, bsd_type: str) -> dict:
+    # a few matches are missing, but should not appear in results
     verbose = status
     match status:
         case BsdStatus.DRAFT:
@@ -103,110 +104,31 @@ def status_badge(status: str, bsd_type: str) -> dict:
             verbose = TRAITE
         case BsdStatus.AWAITING_CHILD:
             verbose = TRAITE
-
+        case BsdStatus.GROUPED:
+            if bsd_type == TYPE_BSFF:
+                verbose = EN_ATTENTE_TRAITEMENT
+            if bsd_type == TYPE_BSDA:
+                verbose = ANNEXE_BORDEREAU_SUITE
+        case BsdStatus.NO_TRACEABILITY:
+            verbose = TRAITE_AVEC_RUPTURE_TRACABILITE
+        case BsdStatus.REFUSED:
+            verbose = REFUSE
+        case BsdStatus.TEMP_STORED:
+            verbose = ARRIVE_ENTREPOS_PROVISOIRE
+        case BsdStatus.TEMP_STORER_ACCEPTED:
+            verbose = ENTREPOS_TEMPORAIREMENT
+        case BsdStatus.RESEALED:
+            verbose = BSD_SUITE_PREPARE
+        case BsdStatus.RESENT:
+            verbose = SIGNE_PAR_TRANSPORTEUR
+        case BsdStatus.SIGNED_BY_PRODUCER:
+            verbose = SIGNE_PAR_EMETTEUR
+        case BsdStatus.SIGNED_BY_TEMP_STORER:
+            verbose = SIGNER_PAR_ENTREPOS_PROVISOIRE
+        case BsdStatus.PARTIALLY_REFUSED:
+            verbose = PARTIELLEMENT_REFUSE
+        case BsdStatus.FOLLOWED_WITH_PNTTD:
+            verbose = SUIVI_PAR_PNTTD
+        case BsdStatus.SI:
+            verbose = SUIVI_PAR_PNTTD
     return {"status": status, "verbose": verbose}
-
-
-"""
-
-  switch (status) {
-    case BsdStatusCode.Draft:
-      return BROUILLON;
-    case BsdStatusCode.Sealed:
-      return INITIAL;
-    case BsdStatusCode.Sent:
-      if (bsdType && transporters && transporters.length > 1) {
-        // Le code qui suit permet d'afficher "Signé par le transporteur N"
-        // en cas de transport multi-modal
-        let lastTransporterNumero: Maybe<number> = null;
-        if (isBsdd(bsdType)) {
-          lastTransporterNumero = (transporters as Transporter[]).filter(t =>
-            Boolean(t.takenOverAt)
-          ).length;
-        } else if (isBsda(bsdType) || isBsff(bsdType)) {
-          lastTransporterNumero = (transporters as BsdaTransporter[]).filter(
-            t => Boolean(t.transport?.signature?.date)
-          ).length;
-        }
-        if (lastTransporterNumero)
-          return SIGNE_PAR_TRANSPORTEUR_N(lastTransporterNumero);
-      }
-      return SIGNE_PAR_TRANSPORTEUR;
-    case BsdStatusCode.Received:
-      if (bsdType === BsdType.Bsdasri) {
-        return ACCEPTE;
-      }
-      if (bsdType === BsdType.Bspaoh) {
-        return ACCEPTE;
-      }
-      return RECU;
-    case BsdStatusCode.Accepted:
-      return ACCEPTE;
-    case BsdStatusCode.Processed:
-      return TRAITE;
-    case BsdStatusCode.AwaitingChild:
-    case BsdStatusCode.Grouped:
-      if (bsdType === BsdType.Bsff) {
-        return EN_ATTENTE_TRAITEMENT;
-      }
-      if (bsdType === BsdType.Bsda) {
-        if (bsdaAnnexed) {
-          return ANNEXE_BORDEREAU_SUITE;
-        }
-        return EN_ATTENTE_BSD_SUITE;
-      }
-      return ANNEXE_BORDEREAU_SUITE;
-    case BsdStatusCode.NoTraceability:
-      return TRAITE_AVEC_RUPTURE_TRACABILITE;
-    case BsdStatusCode.Refused:
-      return REFUSE;
-    case BsdStatusCode.TempStored:
-      return ARRIVE_ENTREPOS_PROVISOIRE;
-    case BsdStatusCode.TempStorerAccepted:
-      return ENTREPOS_TEMPORAIREMENT;
-    case BsdStatusCode.Resealed:
-      return BSD_SUITE_PREPARE;
-    case BsdStatusCode.Resent:
-      return SIGNE_PAR_TRANSPORTEUR;
-    case BsdStatusCode.SignedByProducer:
-      return SIGNE_PAR_EMETTEUR;
-    case BsdStatusCode.Initial:
-      if (isDraft) {
-        return BROUILLON;
-      } else {
-        return INITIAL;
-      }
-    case BsdStatusCode.SignedByEmitter:
-      return SIGNE_PAR_EMETTEUR;
-    case BsdStatusCode.SignedByTempStorer:
-      return SIGNER_PAR_ENTREPOS_PROVISOIRE;
-    case BsdStatusCode.PartiallyRefused:
-      return PARTIELLEMENT_REFUSE;
-    case BsdStatusCode.FollowedWithPnttd:
-      return SUIVI_PAR_PNTTD;
-    case BsdStatusCode.SignedByWorker:
-      return SIGNER_PAR_ENTREPRISE_TRAVAUX;
-    case BsdStatusCode.AwaitingGroup:
-      if (bsdType === BsdType.Bsdasri) {
-        if (operationCode === "R12" || operationCode === "D13") {
-          return EN_ATTENTE_BSD_SUITE;
-        }
-        return ANNEXE_BORDEREAU_SUITE;
-      }
-      return EN_ATTENTE_BSD_SUITE;
-    case BsdStatusCode.IntermediatelyProcessed:
-      if (bsdType === BsdType.Bsff) {
-        return EN_ATTENTE_TRAITEMENT;
-      }
-      if (bsdType === BsdType.Bsdasri) {
-        return ANNEXE_BORDEREAU_SUITE;
-      }
-      return EN_ATTENTE_BSD_SUITE;
-    case BsdStatusCode.Canceled:
-      return ANNULE;
-
-    default:
-      return "unknown status";
-  }
-
-"""

--- a/src/roadcontrol/tests/test_converters.py
+++ b/src/roadcontrol/tests/test_converters.py
@@ -140,6 +140,7 @@ def test_bsda_to_bsd_display():
         "transporter": {"company": {"name": "TRANSPORT", "siret": "thesiret"}, "transport": {"plates": ["34ER36"]}},
         "waste": {"adr": "non soumis", "bsdaWasteCode": "17 06 05*", "materialName": "amiante ciment lié"},
         "weight": {"value": 10.1},
+        "bsdaUpdatedAt": "2024-11-15T09:43:13.790Z",
     }
 
     bsd_display = bsda_to_bsd_display(es_bsda)
@@ -149,7 +150,7 @@ def test_bsda_to_bsd_display():
         "status": "SENT",
         "id": "BSDA-123-XYZ",
         "readable_id": "BSDA-123-XYZ",
-        "updated_at": "",
+        "updated_at": "15/11/2024",
         "adr": "non soumis",
         "waste_details": {"code": "17 06 05*", "name": "amiante ciment lié", "weight": "10.1"},
         "emitter": {"company": {"name": "EMITTER"}},

--- a/src/roadcontrol/tests/test_converters.py
+++ b/src/roadcontrol/tests/test_converters.py
@@ -66,9 +66,10 @@ def test_bsdasri_to_bsd_display():
             "company": {"name": "THE COMPANY", "siret": "thesiret"},
             "transport": {"plates": ["DQ-199-NS"], "weight": {"value": 12}},
         },
-        "updatedAt": "2024-11-15T09:43:13.790Z",
+        "bsdasriUpdatedAt": "2024-11-15T09:43:13.790Z",
     }
     bsd_display = bsdasri_to_bsd_display(es_bsdasri)
+
     assert bsd_display == {
         "bsd_type": "BSDASRI",
         "status": "SENT",

--- a/src/roadcontrol/views.py
+++ b/src/roadcontrol/views.py
@@ -323,8 +323,6 @@ class BsdSearchResult(FullyLoggedMixin, FormView):
 
             edges = bsds["edges"]
 
-            print(len(edges))
-
             nodes = [edge["node"] for edge in edges]
 
         converter = BsdsToBsdsDisplay(nodes)

--- a/src/roadcontrol/views.py
+++ b/src/roadcontrol/views.py
@@ -1,5 +1,6 @@
 import httpx
 from celery.result import AsyncResult
+from django.conf import settings
 from django.core.files.base import ContentFile
 from django.shortcuts import redirect
 from django.views.generic import DetailView, FormView, TemplateView
@@ -14,7 +15,25 @@ from .forms import BsdSearchForm, RoadControlSearchForm
 from .helpers import get_company_data
 from .models import BsdPdf, PdfBundle
 from .task import prepare_bundle
-from .td_requests import query_td_bsd_id, query_td_bsds, query_td_pdf
+from .td_requests import query_td_bsd_id, query_td_bsds, query_td_control_bsds, query_td_pdf
+
+
+def get_query_fn():
+    if settings.USE_CONTROL_BSDS_QUERY:
+        return query_td_control_bsds
+    return query_td_bsds
+
+
+def get_query_id_fn():
+    if settings.USE_CONTROL_BSDS_QUERY:
+        return query_td_control_bsds
+    return query_td_bsd_id
+
+
+def get_query_name():
+    if settings.USE_CONTROL_BSDS_QUERY:
+        return "controlBsds"
+    return "bsds"
 
 
 class RoadControlSearch(FullyLoggedMixin, TemplateView):
@@ -35,7 +54,11 @@ class RoadControlSearchResult(FullyLoggedMixin, FormView):
         plate = form.cleaned_data["plate"]
 
         form_end_cursor = form.cleaned_data.get("end_cursor", None)
-        resp = query_td_bsds(siret, plate, end_cursor=form_end_cursor)
+
+        query_fn = get_query_fn()
+        query_name = get_query_name()
+        resp = query_fn(siret=siret, plate=plate, end_cursor=form_end_cursor)
+
         nodes = []
         total_count = 0
 
@@ -45,7 +68,7 @@ class RoadControlSearchResult(FullyLoggedMixin, FormView):
         has_previous_page = False
 
         if resp:
-            bsds = resp["data"]["bsds"]
+            bsds = resp["data"][query_name]
             total_count = bsds["totalCount"]
             page_info = bsds["pageInfo"]
             start_cursor = page_info["startCursor"]
@@ -281,7 +304,10 @@ class BsdSearchResult(FullyLoggedMixin, FormView):
     def form_valid(self, form):
         bsd_id = form.cleaned_data["bsd_id"]
 
-        resp = query_td_bsd_id(bsd_id)
+        query_fn = get_query_id_fn()
+        query_name = get_query_name()
+        resp = query_fn(bsd_id=bsd_id)
+        breakpoint()
         nodes = []
         total_count = 0
         start_cursor = None
@@ -289,13 +315,15 @@ class BsdSearchResult(FullyLoggedMixin, FormView):
         has_next_page = False
         has_previous_page = False
         if resp:
-            bsds = resp["data"]["bsds"]
+            bsds = resp["data"][query_name]
             total_count = bsds["totalCount"]
             page_info = bsds["pageInfo"]
             start_cursor = page_info["startCursor"]
             end_cursor = page_info["endCursor"]
 
             edges = bsds["edges"]
+
+            print(len(edges))
 
             nodes = [edge["node"] for edge in edges]
 

--- a/src/templates/roadcontrol/partials/_bsd_card.html
+++ b/src/templates/roadcontrol/partials/_bsd_card.html
@@ -5,7 +5,7 @@
             <p class="bsd-number">N°: {{ bsd.readable_id }}</p>
             <div class="bsd-card__header__infos">
                 <p class="label-icon label-icon__LastModificationDate">Modifié le {{ bsd.updated_at }}</p>
-                <p class="label-icon label-icon__TransporterNumberPlate">{{ bsd.transporter_plate }}</p>
+                <p class="label-icon label-icon__TransporterNumberPlate">{{ bsd.transporter_plate|default:"N/A" }}</p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
La fiche établissement exploite la query bsds pour effectuer des recherches par siret (transporteur), plaque ou readableId sur l'ensemble des bsds.

L'introduction de l'onglet retour nécessitait soit de modifier cette query avec des filtres qui s'intégraient mal avec l'existant (le bsd doit porter la plaque xyz et être dans un onglet collecté ou retour, le siret n'étant pas fourni en paramètre).

Il a été jugé plus pertinent d'écrire une query spécialisée et simplifiée: controlBsds, réservée aux users rattachés à un compte gouvernemental disposant des perms adéquates.


La fiche établissement permet désormais d'utiliser cette query via la variable USE_CONTROL_BSDS_QUERY
- [x] Mettre à jour le change log
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14965)
