### PR TITLE
Corrige un bug pour les données SSD

### DIFF
--- a/src/sheets/graph_processors/html_components_processors.py
+++ b/src/sheets/graph_processors/html_components_processors.py
@@ -2456,9 +2456,12 @@ class RNDTSStatsProcessor:
                         self.stats[f"total_{key}_incoming"] = total
 
         if outgoing_data is not None:
+            colname = "producteur_numero_identification"
+            if "producteur_numero_identification" not in outgoing_data.columns:
+                colname = "etablissement_numero_identification"  # SSD case
             outgoing_data = outgoing_data[
                 outgoing_data["date_expedition"].between(*self.data_date_interval)
-                & (outgoing_data["producteur_numero_identification"] == self.company_siret)
+                & (outgoing_data[colname] == self.company_siret)
             ]
             if len(outgoing_data) > 0:
                 self.stats["total_statements_outgoing"] = outgoing_data["id"].nunique()

--- a/src/sheets/graph_processors/plotly_components_processors.py
+++ b/src/sheets/graph_processors/plotly_components_processors.py
@@ -1677,9 +1677,13 @@ class RNDTSQuantitiesGraphProcessor:
 
         outgoing_data = self.rndts_outgoing_data
         if (outgoing_data is not None) and (len(outgoing_data) > 0):
+            colname = "producteur_numero_identification"
+            if "producteur_numero_identification" not in outgoing_data.columns:
+                colname = "etablissement_numero_identification"  # SSD case
+
             outgoing_data = outgoing_data[
                 outgoing_data["date_expedition"].between(*self.data_date_interval)
-                & (outgoing_data["producteur_numero_identification"] == self.company_siret)
+                & (outgoing_data[colname] == self.company_siret)
             ]
 
             if len(outgoing_data) > 0:
@@ -1894,9 +1898,12 @@ class RNDTSStatementsGraphProcessor:
 
         outgoing_data = self.rndts_outgoing_data
         if (outgoing_data is not None) and (len(outgoing_data) > 0):
+            colname = "producteur_numero_identification"
+            if "producteur_numero_identification" not in outgoing_data.columns:
+                colname = "etablissement_numero_identification"  # SSD case
             outgoing_data = outgoing_data[
                 outgoing_data["date_expedition"].between(*self.data_date_interval)
-                & (outgoing_data["producteur_numero_identification"] == self.company_siret)
+                & (outgoing_data[colname] == self.company_siret)
             ].dropna(subset=["date_expedition"])
 
             if len(outgoing_data) > 0:

--- a/src/sheets/tests/test_rndts_quantities_graph_processor.py
+++ b/src/sheets/tests/test_rndts_quantities_graph_processor.py
@@ -7,7 +7,9 @@ from ..graph_processors.plotly_components_processors import RNDTSQuantitiesGraph
 
 
 @pytest.fixture
-def sample_data():
+def sample_data(request):
+    ssd_mode: bool = request.param
+
     incoming_data = pd.DataFrame(
         {
             "id": [1, 2, 3, 4, 5],
@@ -30,6 +32,8 @@ def sample_data():
         }
     )
 
+    key_name = "producteur_numero_identification" if not ssd_mode else "etablissement_numero_identification"
+
     outgoing_data = pd.DataFrame(
         {
             "id": [6, 7, 8, 9, 10],
@@ -40,7 +44,7 @@ def sample_data():
                 datetime(2024, 8, 15),
                 datetime(2024, 8, 16),
             ],
-            "producteur_numero_identification": [
+            key_name: [
                 "12345678901234",
                 "12345678901234",
                 "98765432109876",  # Different SIRET
@@ -57,6 +61,7 @@ def sample_data():
     return incoming_data, outgoing_data, date_interval
 
 
+@pytest.mark.parametrize("sample_data", [False, True], indirect=True)
 def test_initialization(sample_data):
     incoming_data, outgoing_data, date_interval = sample_data
 
@@ -78,6 +83,7 @@ def test_initialization(sample_data):
     assert processor.figure is None
 
 
+@pytest.mark.parametrize("sample_data", [False, True], indirect=True)
 def test_preprocess_data(sample_data):
     incoming_data, outgoing_data, date_interval = sample_data
 
@@ -105,6 +111,7 @@ def test_preprocess_data(sample_data):
     assert processor.outgoing_volume_by_month_serie.sum() == 70  # 25 + 45
 
 
+@pytest.mark.parametrize("sample_data", [False, True], indirect=True)
 def test_check_data_empty(sample_data):
     incoming_data, outgoing_data, date_interval = sample_data
 
@@ -133,6 +140,7 @@ def test_check_data_empty(sample_data):
     assert processor._check_data_empty()
 
 
+@pytest.mark.parametrize("sample_data", [False, True], indirect=True)
 def test_create_figure(sample_data):
     incoming_data, outgoing_data, date_interval = sample_data
 
@@ -149,6 +157,7 @@ def test_create_figure(sample_data):
     assert processor.figure is not None
 
 
+@pytest.mark.parametrize("sample_data", [False, True], indirect=True)
 def test_build_output(sample_data):
     incoming_data, outgoing_data, date_interval = sample_data
 

--- a/src/sheets/tests/test_rndts_statements_graph_processor.py
+++ b/src/sheets/tests/test_rndts_statements_graph_processor.py
@@ -7,7 +7,9 @@ from ..graph_processors.plotly_components_processors import RNDTSStatementsGraph
 
 
 @pytest.fixture
-def sample_data():
+def sample_data(request):
+    ssd_mode: bool = request.param
+
     incoming_data = pd.DataFrame(
         {
             "id": [1, 2, 3, 4],
@@ -26,6 +28,7 @@ def sample_data():
         }
     )
 
+    key_name = "producteur_numero_identification" if not ssd_mode else "etablissement_numero_identification"
     outgoing_data = pd.DataFrame(
         {
             "id": [4, 5, 6],
@@ -34,7 +37,7 @@ def sample_data():
                 datetime(2024, 8, 12),
                 datetime(2024, 8, 1),
             ],
-            "producteur_numero_identification": [
+            key_name: [
                 "12345678901234",
                 "12345678901234",
                 "98765432109876",
@@ -47,6 +50,7 @@ def sample_data():
     return incoming_data, outgoing_data, date_interval
 
 
+@pytest.mark.parametrize("sample_data", [False, True], indirect=True)
 def test_initialization(sample_data):
     incoming_data, outgoing_data, date_interval = sample_data
 
@@ -68,6 +72,7 @@ def test_initialization(sample_data):
     assert processor.figure is None
 
 
+@pytest.mark.parametrize("sample_data", [False, True], indirect=True)
 def test_preprocess_bs_data(sample_data):
     incoming_data, outgoing_data, date_interval = sample_data
 
@@ -90,6 +95,7 @@ def test_preprocess_bs_data(sample_data):
     assert processor.statements_emitted_by_month_serie.sum() == 2
 
 
+@pytest.mark.parametrize("sample_data", [False, True], indirect=True)
 def test_check_data_empty(sample_data):
     incoming_data, outgoing_data, date_interval = sample_data
 
@@ -118,6 +124,7 @@ def test_check_data_empty(sample_data):
     assert processor._check_data_empty()
 
 
+@pytest.mark.parametrize("sample_data", [False, True], indirect=True)
 def test_create_figure(sample_data):
     incoming_data, outgoing_data, date_interval = sample_data
 
@@ -135,6 +142,7 @@ def test_create_figure(sample_data):
     assert processor.figure is not None
 
 
+@pytest.mark.parametrize("sample_data", [False, True], indirect=True)
 def test_build_output(sample_data):
     incoming_data, outgoing_data, date_interval = sample_data
 

--- a/src/sheets/tests/test_rndts_stats_processor.py
+++ b/src/sheets/tests/test_rndts_stats_processor.py
@@ -1,0 +1,153 @@
+import pytest
+import pandas as pd
+from datetime import datetime, timedelta
+from ..graph_processors.html_components_processors import RNDTSStatsProcessor
+
+
+# Sample fixture for test data
+@pytest.fixture
+def rndts_test_data(request):
+    ssd_mode: bool = request.param
+
+    incoming_data = pd.DataFrame(
+        {
+            "id": [1, 2, 3, 4, 5],
+            "date_reception": [
+                datetime(2024, 8, 9),
+                datetime(2024, 8, 10),
+                datetime(2024, 7, 15),  # Outside date interval
+                datetime(2024, 8, 11),
+                datetime(2024, 9, 12),
+            ],
+            "etablissement_numero_identification": [
+                "12345678901234",
+                "12345678901234",
+                "98765432109876",  # Different SIRET
+                "12345678901234",
+                "12345678901234",
+            ],
+            "unite": ["T", "M3", "T", "M3", "T"],
+            "quantite": [10, 20, 30, 40, 50],
+        }
+    )
+    key_name = "producteur_numero_identification" if not ssd_mode else "etablissement_numero_identification"
+    outgoing_data = pd.DataFrame(
+        {
+            "id": [6, 7, 8, 9, 10],
+            "date_expedition": [
+                datetime(2024, 8, 13),
+                datetime(2024, 8, 14),
+                datetime(2024, 10, 1),  # Outside date interval
+                datetime(2024, 8, 15),
+                datetime(2024, 8, 16),
+            ],
+            key_name: [
+                "12345678901234",
+                "12345678901234",
+                "98765432109876",  # Different SIRET
+                "12345678901234",
+                "12345678901234",
+            ],
+            "unite": ["T", "M3", "T", "M3", "T"],
+            "quantite": [15, 25, 35, 45, 55],
+        }
+    )
+
+    date_interval = (datetime(2024, 8, 1), datetime(2024, 9, 30))
+    company_siret = "12345678901234"
+
+    return company_siret, incoming_data, outgoing_data, date_interval
+
+
+@pytest.mark.parametrize("rndts_test_data", [False, True], indirect=True)
+def test_preprocess_data(rndts_test_data):
+    """Test preprocessing of incoming and outgoing data."""
+    company_siret, incoming_data, outgoing_data, date_interval = rndts_test_data
+
+    processor = RNDTSStatsProcessor(company_siret, incoming_data, outgoing_data, date_interval)
+    processor._preprocess_data()
+
+    assert processor.stats["total_weight_incoming"] == 60
+    assert processor.stats["total_volume_incoming"] == 60
+    assert processor.stats["total_statements_incoming"] == 4
+
+    assert processor.stats["total_weight_outgoing"] == 70
+    assert processor.stats["total_volume_outgoing"] == 70
+    assert processor.stats["total_statements_outgoing"] == 4
+
+
+@pytest.mark.parametrize("rndts_test_data", [False, True], indirect=True)
+def test_empty_data_handling(rndts_test_data):
+    """Test handling of empty dataframes."""
+    company_siret, incoming_data, outgoing_data, date_interval = rndts_test_data
+
+    processor = RNDTSStatsProcessor(company_siret, incoming_data.head(0), outgoing_data.head(0), date_interval)
+    processor._preprocess_data()
+
+    assert processor._check_data_empty()
+
+    # Case empty data due to date interval miss
+    processor = RNDTSStatsProcessor(
+        company_siret,
+        incoming_data.head(0),
+        outgoing_data.head(0),
+        tuple(e - timedelta(days=365) for e in date_interval),
+    )
+    processor._preprocess_data()
+
+    assert processor._check_data_empty()
+
+
+@pytest.mark.parametrize("rndts_test_data", [False, True], indirect=True)
+def test_bar_size_calculation(rndts_test_data):
+    """Test bar size calculation for incoming and outgoing data."""
+    company_siret, incoming_data, outgoing_data, date_interval = rndts_test_data
+
+    processor = RNDTSStatsProcessor(company_siret, incoming_data, outgoing_data, date_interval)
+    processor._preprocess_data()
+
+    assert processor.stats["bar_size_weight_incoming"] == 85  # Relative size
+    assert processor.stats["bar_size_weight_outgoing"] == 100
+
+    assert processor.stats["bar_size_volume_incoming"] == 85  # Relative size
+    assert processor.stats["bar_size_volume_outgoing"] == 100
+
+
+@pytest.mark.parametrize("rndts_test_data", [False, True], indirect=True)
+def test_context_building(rndts_test_data):
+    """Test that context is correctly built and formatted."""
+    company_siret, incoming_data, outgoing_data, date_interval = rndts_test_data
+
+    processor = RNDTSStatsProcessor(company_siret, incoming_data, outgoing_data, date_interval)
+    processor._preprocess_data()
+    context = processor.build_context()
+
+    assert context["total_weight_incoming"] == "60"
+    assert context["total_weight_outgoing"] == "70"
+    assert context["total_statements_incoming"] == "4"
+    assert context["total_statements_outgoing"] == "4"
+
+
+@pytest.mark.parametrize("rndts_test_data", [False, True], indirect=True)
+def test_full_build(rndts_test_data):
+    """Test the full build method."""
+    company_siret, incoming_data, outgoing_data, date_interval = rndts_test_data
+
+    processor = RNDTSStatsProcessor(company_siret, incoming_data, outgoing_data, date_interval)
+    data = processor.build()
+
+    expected_data = {
+        "total_weight_incoming": "60",
+        "total_weight_outgoing": "70",
+        "bar_size_weight_incoming": "85",
+        "bar_size_weight_outgoing": "100",
+        "has_weight": True,
+        "total_volume_incoming": "60",
+        "total_volume_outgoing": "70",
+        "bar_size_volume_incoming": "85",
+        "bar_size_volume_outgoing": "100",
+        "has_volume": True,
+        "total_statements_incoming": "4",
+        "total_statements_outgoing": "4",
+    }
+    assert data == expected_data


### PR DESCRIPTION
Les données SSD n'ont pas de SIRET producteur bien que ce soit considéré comme un registre "sortant" dans le traitement des données. Maintenant, un test est utilisé pour sélectionner la bonne colonne.

Aussi des tests ont été ajoutés pour le `RNDSStatsProcessor`
<!--
  Décrivez brièvement l'objectif de votre pull request.
  La liste ci-dessous comporte des éléments importants à garder en tête pour chaque PR.
  Pensez à ajouter le lien du ticket Favro correspondant.
-->

- [ ] Mettre à jour le change log
---

- [Ticket Favro]()
