### PR TITLE
Utilisation de la quantité estimée pour les bordereaux d'annexe 1

### DIFF
--- a/src/sheets/queries.py
+++ b/src/sheets/queries.py
@@ -10,7 +10,11 @@ select
     emitter_company_address,
     recipient_company_siret,
     waste_details_quantity,
-    quantity_received,
+    case 
+        when (emitter_company_siret = :siret) and (emitter_type = 'APPENDIX1_PRODUCER') 
+        then waste_details_quantity -- For appendix 1 we take the estimated quantity as received quantity
+        else quantity_received
+    end as quantity_received,
     waste_details_code as waste_code,
     waste_details_name as waste_name,
     processing_operation_done as processing_operation_code,


### PR DESCRIPTION
Lorsque qu'un producteur est mentionné dans des bordereaux d'annexe 1 (bordereaux enfants), il n'y a pas la possibilité d'extraire la quantité pesée à l'arrivée car seul le bordereau chapeau a une quantité pesée.
Dans ce cas précis, on utilise de manière transparente la quantitée estimée au départ pour les différents composants.



- [ ] Mettre à jour le change log
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/37a331c647a38a191b2a1207?card=tra-14467)
