### PR TITLE
Fix plate length control

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,9 +5,13 @@ Les changements importants de Trackdéchets préparation inspection sont documen
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versioning inspiré de [Calendar Versioning](https://calver.org/).
 
+## 01/01/2025
+
+- Correction de la recherche par plaque
+
 ## 26/11/2024
 
-- Ajout de la cartographie des établissments
+- Ajout de la cartographie des établissements
 
 ## 25/11/2024
 

--- a/src/roadcontrol/forms.py
+++ b/src/roadcontrol/forms.py
@@ -52,7 +52,7 @@ class RoadControlSearchForm(Form):
         if not plate and not siret:
             raise ValidationError("Au moins un champ est requis")
 
-        if len("".join(plate.split())) <= 6 and not siret:
+        if len("".join(plate.split())) < 6 and not siret:
             self.add_error(
                 "plate", "L'immatriculation doit être renseignée en entier si vous ne précisez pas le siret"
             )


### PR DESCRIPTION
Corrige la validation de la longueur du chap de recherche par plaque, qui nécessitait plus de 6 caractères (>) quand le siret n'est pas fourni (hors tirets et espace) et passe à 6 inclus (>=)

Pb décelé dans le cadre du ticket cité en référence

- [x] Mettre à jour le change log
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15658)
