### PR TITLE
Masque la mention de téléchargement de registre après un délai.

### DIFF
--- a/src/templates/scripts/registry_form_submit.html
+++ b/src/templates/scripts/registry_form_submit.html
@@ -4,17 +4,16 @@
 
         const form = document.querySelector('#id_registry_prepare_form');
         const messageContainer = document.querySelector('#id_registry_prepare_message');
-        const  button = document.querySelector('#id_registry_prepare_button');
+        const button = document.querySelector('#id_registry_prepare_button');
 
 
         form.addEventListener('submit', e => {
-
-
             button.disabled = true;
             messageContainer.innerText = "Le téléchargement va débuter, veuillez patienter"
-
-
-
+            setTimeout(() => {
+                button.disabled = false;
+                messageContainer.innerText = ""
+            }, 3000)
         })
     })()
 </script>


### PR DESCRIPTION
 El patron trouvait gênant que le message reste affiché et le bouton disabled, on laisse affiché qq secondes seulement.

https://github.com/user-attachments/assets/42277e45-6a6d-4b51-99ea-7facd320200e



- [ ] Mettre à jour le change log
---

- [Ticket Favro]()
