### PR TITLE
Correction d'un bug sur le composant BsdQuantitiesGraph avec BSFF

### DIFF
--- a/src/sheets/graph_processors/plotly_components_processors.py
+++ b/src/sheets/graph_processors/plotly_components_processors.py
@@ -105,8 +105,7 @@ class BsdQuantitiesGraph:
                 incoming_data = incoming_data.merge(self.packagings_data, left_on="id", right_on="bsff_id")
                 if not incoming_data["acceptation_date"].isna().all():
                     incoming_data_by_month = (
-                        incoming_data.merge(self.packagings_data, left_on="id", right_on="bsff_id")
-                        .groupby(pd.Grouper(key="acceptation_date", freq="1M"))[variable_name]
+                        incoming_data.groupby(pd.Grouper(key="acceptation_date", freq="1M"))[variable_name]
                         .sum()
                         .replace(0, np.nan)
                     )
@@ -114,8 +113,7 @@ class BsdQuantitiesGraph:
                 outgoing_data = outgoing_data.merge(self.packagings_data, left_on="id", right_on="bsff_id")
                 if not outgoing_data["sent_at"].isna().all():
                     outgoing_data_by_month = (
-                        outgoing_data.merge(self.packagings_data, left_on="id", right_on="bsff_id")
-                        .groupby(pd.Grouper(key="sent_at", freq="1M"))[variable_name]
+                        outgoing_data.groupby(pd.Grouper(key="sent_at", freq="1M"))[variable_name]
                         .sum()
                         .replace(0, np.nan)
                     )

--- a/src/sheets/graph_processors/plotly_components_processors.py
+++ b/src/sheets/graph_processors/plotly_components_processors.py
@@ -98,18 +98,27 @@ class BsdQuantitiesGraph:
                 if self.packagings_data is None:
                     # Case when there is BSFFs but no packagings info
                     continue
-                incoming_data_by_month = (
-                    incoming_data.merge(self.packagings_data, left_on="id", right_on="bsff_id")
-                    .groupby(pd.Grouper(key="acceptation_date", freq="1M"))[variable_name]
-                    .sum()
-                    .replace(0, np.nan)
-                )
-                outgoing_data_by_month = (
-                    outgoing_data.merge(self.packagings_data, left_on="id", right_on="bsff_id")
-                    .groupby(pd.Grouper(key="sent_at", freq="1M"))[variable_name]
-                    .sum()
-                    .replace(0, np.nan)
-                )
+
+                incoming_data_by_month = pd.Series()
+                outgoing_data_by_month = pd.Series()
+
+                incoming_data = incoming_data.merge(self.packagings_data, left_on="id", right_on="bsff_id")
+                if not incoming_data["acceptation_date"].isna().all():
+                    incoming_data_by_month = (
+                        incoming_data.merge(self.packagings_data, left_on="id", right_on="bsff_id")
+                        .groupby(pd.Grouper(key="acceptation_date", freq="1M"))[variable_name]
+                        .sum()
+                        .replace(0, np.nan)
+                    )
+
+                outgoing_data = outgoing_data.merge(self.packagings_data, left_on="id", right_on="bsff_id")
+                if not outgoing_data["sent_at"].isna().all():
+                    outgoing_data_by_month = (
+                        outgoing_data.merge(self.packagings_data, left_on="id", right_on="bsff_id")
+                        .groupby(pd.Grouper(key="sent_at", freq="1M"))[variable_name]
+                        .sum()
+                        .replace(0, np.nan)
+                    )
             else:
                 # Handle quantity refused
                 if self.bs_type in [BSDD, BSDD_NON_DANGEROUS, BSDASRI]:

--- a/src/sheets/tests/test_bsd_quantites_graph.py
+++ b/src/sheets/tests/test_bsd_quantites_graph.py
@@ -1,0 +1,154 @@
+import pytest
+import pandas as pd
+import numpy as np
+from datetime import datetime
+
+from sheets.constants import BSDD, BSFF
+from ..graph_processors.plotly_components_processors import (
+    BsdQuantitiesGraph,
+)  # Remplace "your_module" par le bon module
+
+
+@pytest.fixture
+def sample_data_bsdd():
+    data = {
+        "id": [1, 2, 3, 4],
+        "recipient_company_siret": ["12345678900011", "12345678900011", "98765432100022", "12345678900011"],
+        "emitter_company_siret": ["98765432100022", "98765432100022", "12345678900011", "98765432100011"],
+        "received_at": pd.to_datetime(["2024-01-10", "2024-02-15", "2024-03-20", "2024-04-25"]),
+        "sent_at": pd.to_datetime(["2024-01-05", "2024-02-10", "2024-03-15", "2024-04-20"]),
+        "quantity_received": [10, 20, 30, 40],
+        "quantity_refused": [1, None, 2, 40],
+    }
+    return pd.DataFrame(data)
+
+
+@pytest.fixture
+def sample_data_bsff():
+    data = {
+        "id": [1, 2, 3, 4],
+        "recipient_company_siret": ["12345678900011", "98765432100022", "98765432100022", "12345678900011"],
+        "emitter_company_siret": ["98765432100022", "12345678900011", "12345678900011", "98765432100011"],
+        "sent_at": pd.to_datetime(["2024-01-05", "2024-02-10", "2024-03-15", "2024-04-20"]),
+        "received_at": pd.to_datetime(["2024-01-10", "2024-02-15", "2024-03-20", "2024-04-25"]),
+    }
+    return pd.DataFrame(data)
+
+
+@pytest.fixture
+def sample_packagings():
+    data = {
+        "bsff_id": [1, 2, 2, 4, 4],
+        "acceptation_date": pd.to_datetime(["2024-01-12", "2024-02-18", "2024-03-22", "2024-04-28", "2024-04-30"]),
+        "acceptation_weight": [5, 10, 15, 20, 3],
+    }
+    return pd.DataFrame(data)
+
+
+def test_bsd_quantities_graph_bsdd(sample_data_bsdd):
+    company_siret = "12345678900011"
+    bs_type = BSDD  # Remplace par la bonne valeur
+    data_date_interval = (datetime(2024, 1, 1), datetime(2024, 12, 31))
+    quantity_variables_names = ["quantity_received"]
+
+    processor = BsdQuantitiesGraph(
+        company_siret=company_siret,
+        bs_type=bs_type,
+        bs_data=sample_data_bsdd,
+        data_date_interval=data_date_interval,
+        quantity_variables_names=quantity_variables_names,
+    )
+
+    processor._preprocess_data()
+
+    expected_incoming_data_by_month_series = pd.Series(
+        data=[
+            9.0,
+            20.0,
+            np.nan,
+            np.nan,
+        ],
+        index=[
+            pd.Timestamp("2024-01-31 00:00:00", freq="M"),
+            pd.Timestamp("2024-02-29 00:00:00", freq="M"),
+            pd.Timestamp("2024-03-31 00:00:00", freq="M"),
+            pd.Timestamp("2024-04-30 00:00:00", freq="M"),
+        ],
+    )
+    expected_outgoing_data_by_month_series = pd.Series(
+        data=[28.0], index=[pd.Timestamp("2024-03-31 00:00:00", freq="M")]
+    )
+
+    assert processor.incoming_data_by_month_series[0].equals(expected_incoming_data_by_month_series)
+    assert processor.outgoing_data_by_month_series[0].equals(expected_outgoing_data_by_month_series)
+
+
+def test_bsd_quantities_graph_bsff(sample_data_bsff, sample_packagings):
+    company_siret = "12345678900011"
+    bs_type = BSFF  # Remplace par la bonne valeur
+    data_date_interval = (datetime(2024, 1, 1), datetime(2024, 12, 31))
+    quantity_variables_names = [
+        "acceptation_weight",
+    ]
+
+    processor = BsdQuantitiesGraph(
+        company_siret=company_siret,
+        bs_type=bs_type,
+        bs_data=sample_data_bsff,
+        data_date_interval=data_date_interval,
+        quantity_variables_names=quantity_variables_names,
+        packagings_data=sample_packagings,
+    )
+
+    processor._preprocess_data()
+
+    expected_incoming_data_by_month_series = pd.Series(
+        data=[
+            5.0,
+            np.nan,
+            np.nan,
+            23.0,
+        ],
+        index=[
+            pd.Timestamp("2024-01-31 00:00:00", freq="M"),
+            pd.Timestamp("2024-02-29 00:00:00", freq="M"),
+            pd.Timestamp("2024-03-31 00:00:00", freq="M"),
+            pd.Timestamp("2024-04-30 00:00:00", freq="M"),
+        ],
+    )
+    expected_outgoing_data_by_month_series = pd.Series(
+        data=[25], index=[pd.Timestamp("2024-02-29 00:00:00", freq="M")]
+    )
+
+    assert processor.incoming_data_by_month_series[0].equals(expected_incoming_data_by_month_series)
+    assert processor.outgoing_data_by_month_series[0].equals(expected_outgoing_data_by_month_series)
+
+
+def test_bsd_quantities_graph_bsff_without_acceptation_date(sample_data_bsff, sample_packagings):
+    company_siret = "12345678900011"
+    bs_type = BSFF  # Remplace par la bonne valeur
+    data_date_interval = (datetime(2024, 1, 1), datetime(2024, 12, 31))
+    quantity_variables_names = [
+        "acceptation_weight",
+    ]
+
+    sample_packagings["acceptation_date"] = [pd.NaT] * len(sample_packagings)
+
+    processor = BsdQuantitiesGraph(
+        company_siret=company_siret,
+        bs_type=bs_type,
+        bs_data=sample_data_bsff,
+        data_date_interval=data_date_interval,
+        quantity_variables_names=quantity_variables_names,
+        packagings_data=sample_packagings,
+    )
+
+    processor._preprocess_data()
+
+    expected_incoming_data_by_month_series = pd.Series([])
+    expected_outgoing_data_by_month_series = pd.Series(
+        data=[25], index=[pd.Timestamp("2024-02-29 00:00:00", freq="M")]
+    )
+
+    assert processor.incoming_data_by_month_series[0].equals(expected_incoming_data_by_month_series)
+    assert processor.outgoing_data_by_month_series[0].equals(expected_outgoing_data_by_month_series)

--- a/src/sheets/tests/test_bsd_quantites_graph.py
+++ b/src/sheets/tests/test_bsd_quantites_graph.py
@@ -47,7 +47,7 @@ def sample_packagings():
 
 def test_bsd_quantities_graph_bsdd(sample_data_bsdd):
     company_siret = "12345678900011"
-    bs_type = BSDD  # Remplace par la bonne valeur
+    bs_type = BSDD
     data_date_interval = (datetime(2024, 1, 1), datetime(2024, 12, 31))
     quantity_variables_names = ["quantity_received"]
 
@@ -83,9 +83,42 @@ def test_bsd_quantities_graph_bsdd(sample_data_bsdd):
     assert processor.outgoing_data_by_month_series[0].equals(expected_outgoing_data_by_month_series)
 
 
+def test_empty_data(sample_data_bsdd):
+    # Case no data matching dates
+    company_siret = "12345678900011"
+    bs_type = BSDD
+    data_date_interval = (datetime(2025, 1, 1), datetime(2025, 12, 31))
+    quantity_variables_names = ["quantity_received"]
+
+    processor = BsdQuantitiesGraph(
+        company_siret=company_siret,
+        bs_type=bs_type,
+        bs_data=sample_data_bsdd,
+        data_date_interval=data_date_interval,
+        quantity_variables_names=quantity_variables_names,
+    )
+
+    processor._preprocess_data()
+
+    assert processor._check_data_empty() is True
+
+    sample_data_bsdd["quantity_received"] = [np.nan] * len(sample_data_bsdd)
+    sample_data_bsdd["quantity_refused"] = [np.nan] * len(sample_data_bsdd)
+    data_date_interval = (datetime(2024, 1, 1), datetime(2024, 12, 31))
+    processor = BsdQuantitiesGraph(
+        company_siret=company_siret,
+        bs_type=bs_type,
+        bs_data=sample_data_bsdd,
+        data_date_interval=data_date_interval,
+        quantity_variables_names=quantity_variables_names,
+    )
+
+    processor._preprocess_data()
+
+
 def test_bsd_quantities_graph_bsff(sample_data_bsff, sample_packagings):
     company_siret = "12345678900011"
-    bs_type = BSFF  # Remplace par la bonne valeur
+    bs_type = BSFF
     data_date_interval = (datetime(2024, 1, 1), datetime(2024, 12, 31))
     quantity_variables_names = [
         "acceptation_weight",
@@ -126,7 +159,7 @@ def test_bsd_quantities_graph_bsff(sample_data_bsff, sample_packagings):
 
 def test_bsd_quantities_graph_bsff_without_acceptation_date(sample_data_bsff, sample_packagings):
     company_siret = "12345678900011"
-    bs_type = BSFF  # Remplace par la bonne valeur
+    bs_type = BSFF
     data_date_interval = (datetime(2024, 1, 1), datetime(2024, 12, 31))
     quantity_variables_names = [
         "acceptation_weight",


### PR DESCRIPTION
La génération du composant plantait si les données de contenants BSFF avaient l'ensemble de leurs dates d'acceptation vides/NA. 

Ajout de tests sur le composant.

- [ ] Mettre à jour le change log
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/37a331c647a38a191b2a1207?card=tra-15992)
