### PR TITLE
Proconnect oidc workflow creates gendarmerie users

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,10 @@ Les changements importants de Trackdéchets préparation inspection sont documen
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versioning inspiré de [Calendar Versioning](https://calver.org/).
 
+## 27/03/2025
+
+- Au premier login Proconnect, les utilisateurs sont créés (gendarmerie uniquement)
+
 ## 26/03/2025
 
 Migration vers le nouveau DataWarehouse.

--- a/src/accounts/admin.py
+++ b/src/accounts/admin.py
@@ -57,6 +57,10 @@ def send_invitation_email(_, request, queryset):
     for user in queryset:
         if user.last_login:
             continue
+
+        if user.oidc_signup or user.oidc_connexion:
+            continue
+
         current_site = get_current_site(request)
 
         domain = current_site.domain

--- a/src/config/settings/base.py
+++ b/src/config/settings/base.py
@@ -255,7 +255,7 @@ DEFAULT_PROCONNECT_OIDC_RP_SCOPES = (
     "openid email given_name usual_name uid siret idp_id organizational_unit belonging_population custom"
 )
 PROCONNECT_OIDC_RP_SCOPES = env("PROCONNECT_OIDC_RP_SCOPES", default=DEFAULT_PROCONNECT_OIDC_RP_SCOPES)
-PROCONNECT_OIDC_CREATE_USER = False
+PROCONNECT_OIDC_CREATE_USER = True
 PROCONNECT_OIDC_RP_SIGN_ALGO = "RS256"
 PROCONNECT_OIDC_AUTHENTICATION_CALLBACK_URL = "proconnect_oidc_authentication_callback"
 PROCONNECT_OIDC_LOGIN_REDIRECT_URL = "private_home"

--- a/src/oidc/tests/test_proconnect.py
+++ b/src/oidc/tests/test_proconnect.py
@@ -72,10 +72,10 @@ def test_proconnect_oidc_auth_request(anon_client):
 @patch("oidc.backends.ProconnectOidcBackend.verify_token")
 @patch("oidc.backends.ProconnectOidcBackend.get_userinfo")
 def test_proconnect_oidc_callback_success_when_user_exists(
-        mock_get_userinfo,
-        mock_verify_token,
-        mock_get_token,
-        anon_client,
+    mock_get_userinfo,
+    mock_verify_token,
+    mock_get_token,
+    anon_client,
 ):
     """Test successful OIDC authentication callback."""
 
@@ -115,11 +115,11 @@ def test_proconnect_oidc_callback_success_when_user_exists(
 @patch("oidc.backends.ProconnectOidcBackend.verify_token")
 @patch("oidc.backends.ProconnectOidcBackend.get_userinfo")
 def test_proconnect_oidc_callback_fails_when_user_is_not_gendarmerie(
-        mock_get_userinfo,
-        mock_verify_token,
-        mock_get_token,
-        user_category,
-        anon_client,
+    mock_get_userinfo,
+    mock_verify_token,
+    mock_get_token,
+    user_category,
+    anon_client,
 ):
     # A user exists, workflow is correct, but user category is not GENDARME: deny access
     user = UserFactory(oidc_signup="PROCONNECT", user_category=user_category)
@@ -158,10 +158,10 @@ def test_proconnect_oidc_callback_fails_when_user_is_not_gendarmerie(
 @patch("oidc.backends.ProconnectOidcBackend.verify_token")
 @patch("oidc.backends.ProconnectOidcBackend.get_userinfo")
 def test_proconnect_oidc_callback_creates_user_when_user_does_not_exist(
-        mock_get_userinfo,
-        mock_verify_token,
-        mock_get_token,
-        anon_client,
+    mock_get_userinfo,
+    mock_verify_token,
+    mock_get_token,
+    anon_client,
 ):
     user_email = "newuser@email.test"
 
@@ -198,10 +198,10 @@ def test_proconnect_oidc_callback_creates_user_when_user_does_not_exist(
 @patch("oidc.backends.ProconnectOidcBackend.verify_token")
 @patch("oidc.backends.ProconnectOidcBackend.get_userinfo")
 def test_proconnect_oidc_callback_fails_when_no_idp_id(
-        mock_get_userinfo,
-        mock_verify_token,
-        mock_get_token,
-        anon_client,
+    mock_get_userinfo,
+    mock_verify_token,
+    mock_get_token,
+    anon_client,
 ):
     """Test failed OIDC authentication callback."""
 
@@ -237,10 +237,10 @@ def test_proconnect_oidc_callback_fails_when_no_idp_id(
 @patch("oidc.backends.ProconnectOidcBackend.verify_token")
 @patch("oidc.backends.ProconnectOidcBackend.get_userinfo")
 def test_proconnect_oidc_callback_fails_when_idp_id_is_incorrect(
-        mock_get_userinfo,
-        mock_verify_token,
-        mock_get_token,
-        anon_client,
+    mock_get_userinfo,
+    mock_verify_token,
+    mock_get_token,
+    anon_client,
 ):
     """Test failed OIDC authentication callback."""
 

--- a/src/templates/oidc/proconnect_authentication_error.html
+++ b/src/templates/oidc/proconnect_authentication_error.html
@@ -10,7 +10,7 @@
         <div class="fr-alert fr-alert--warning fr-mb-3v">
             <h3 class="fr-alert__title">Erreur</h3>
             <p>Une erreur est survenue, vous ne disposez probablement pas des droits nécessaires.</p>
-            <p>Vous devez être préalablement inscrit pour accéder à ce service via Proconnect.</p>
+            <p>Veuillez noter que l'authentification via Proconnect est actuellement réservée aux forces de Gendarmerie.</p>
         </div>
     </div>
 {% endblock main %}


### PR DESCRIPTION
La création d'users lors du premier login proconnect était désactivée pour ne pas donner accès à toute la Gendarmerie. Il s'avère que ce n'est pas un problème, on réactive donc.

- [x] Mettre à jour le change log
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16188)
