### PR TITLE
Tra 16149/migrate to dwhv2

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -39,6 +39,8 @@ django-vite = "*"
 django-filter = "*"
 boto3 = "*"
 mozilla-django-oidc = "*"
+clickhouse-sqlalchemy = "*"
+sshtunnel = "*"
 
 [dev-packages]
 ruff = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -43,7 +43,6 @@ clickhouse-sqlalchemy = "*"
 sshtunnel = "*"
 
 [dev-packages]
-ruff = "*"
 isort = "*"
 djade = "*"
 pywatchman = "*"
@@ -52,6 +51,7 @@ django-extensions = "*"
 ipykernel = "*"
 bandit = "*"
 mypy = "*"
+ruff = "*"
 
 [requires]
 python_version = "3.11"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -2398,28 +2398,28 @@
         },
         "ruff": {
             "hashes": [
-                "sha256:03482d5c09d90d4ee3f40d97578423698ad895c87314c4de39ed2af945633caa",
-                "sha256:0e2bb706a2be7ddfea4a4af918562fdc1bcb16df255e5fa595bbd800ce322a5a",
-                "sha256:194d8402bceef1b31164909540a597e0d913c0e4952015a5b40e28c146121b5d",
-                "sha256:19f505b643228b417c1111a2a536424ddde0db4ef9023b9e04a46ed8a1cb4656",
-                "sha256:1de4367cca3dac99bcbd15c161404e849bb0bfd543664db39232648dc00112dc",
-                "sha256:2f218f356dd2d995839f1941322ff021c72a492c470f0b26a34f844c29cdf5ba",
-                "sha256:4a091729086dffa4bd070aa5dab7e39cc6b9d62eb2bef8f3d91172d30d599666",
-                "sha256:589d1d9f25b5754ff230dce914a174a7c951a85a4e9270613a2b74231fdac2f5",
-                "sha256:5dc1edd1775270e6aa2386119aea692039781429f0be1e0949ea5884e011aa8e",
-                "sha256:5e2d9126161d0357e5c8f30b0bd6168d2c3872372f14481136d13de9937f79b6",
-                "sha256:68660eab1a8e65babb5229a1f97b46e3120923757a68b5413d8561f8a85d4897",
-                "sha256:81761592f72b620ec8fa1068a6fd00e98a5ebee342a3642efd84454f3031dca9",
-                "sha256:ac3ee4d7c2c92ddfdaedf0bf31b2b176fa7aa8950efc454628d477394d35638b",
-                "sha256:b109c0ad2ececf42e75fa99dc4043ff72a357436bb171900714a9ea581ddef83",
-                "sha256:b908ff4df65dad7b251c9968a2e4560836d8f5487c2f0cc238321ed951ea0504",
-                "sha256:c4cae6c4cc7b9b4017c71114115db0445b00a16de3bcde0946273e8392856f08",
-                "sha256:d1bbc6808bf7b15796cef0815e1dfb796fbd383e7dbd4334709642649625e7c5",
-                "sha256:dc61dd5131742e21103fbbdcad683a8813be0e3c204472d520d9a5021ca8b217"
+                "sha256:0397c2672db015be5aa3d4dac54c69aa012429097ff219392c018e21f5085147",
+                "sha256:0c543bf65d5d27240321604cee0633a70c6c25c9a2f2492efa9f6d4b8e4199bb",
+                "sha256:20967168cc21195db5830b9224be0e964cc9c8ecf3b5a9e3ce19876e8d3a96e3",
+                "sha256:2a2b50ca35457ba785cd8c93ebbe529467594087b527a08d487cf0ee7b3087e9",
+                "sha256:2c5424cc1c4eb1d8ecabe6d4f1b70470b4f24a0c0171356290b1953ad8f0e272",
+                "sha256:3170150172a8f994136c0c66f494edf199a0bbea7a409f649e4bc8f4d7084080",
+                "sha256:52933095158ff328f4c77af3d74f0379e34fd52f175144cefc1b192e7ccd32b4",
+                "sha256:6e8fb75e14560f7cf53b15bbc55baf5ecbe373dd5f3aab96ff7aa7777edd7630",
+                "sha256:7c69c74bf53ddcfbc22e6eb2f31211df7f65054bfc1f72288fc71e5f82db3eab",
+                "sha256:842a472d7b4d6f5924e9297aa38149e5dcb1e628773b70e6387ae2c97a63c58f",
+                "sha256:869bcf3f9abf6457fbe39b5a37333aa4eecc52a3b99c98827ccc371a8e5b6f1b",
+                "sha256:86b3a27c38b8fce73bcd262b0de32e9a6801b76d52cdb3ae4c914515f0cef608",
+                "sha256:955a9ce63483999d9f0b8f0b4a3ad669e53484232853054cc8b9d51ab4c5de74",
+                "sha256:a3b66a03b248c9fcd9d64d445bafdf1589326bee6fc5c8e92d7562e58883e30f",
+                "sha256:aca01ccd0eb5eb7156b324cfaa088586f06a86d9e5314b0eb330cb48415097cc",
+                "sha256:c69e20ea49e973f3afec2c06376eb56045709f0212615c1adb0eda35e8a4e477",
+                "sha256:ec47591497d5a1050175bdf4e1a4e6272cddff7da88a2ad595e1e326041d8d94",
+                "sha256:ecf20854cc73f42171eedb66f006a43d0a21bfb98a2523a809931cda569552d9"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==0.9.6"
+            "version": "==0.11.2"
         },
         "setuptools": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8528e26aa23147a8da879b1c571d212ff3a10665a640cde4af452b95ae6944fd"
+            "sha256": "e608b3114294cf3a3c06d62fbaa008fd2f64b548902b93a6543ced1806e80ed2"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -39,6 +39,63 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==3.8.1"
+        },
+        "bcrypt": {
+            "hashes": [
+                "sha256:0042b2e342e9ae3d2ed22727c1262f76cc4f345683b5c1715f0250cf4277294f",
+                "sha256:0142b2cb84a009f8452c8c5a33ace5e3dfec4159e7735f5afe9a4d50a8ea722d",
+                "sha256:08bacc884fd302b611226c01014eca277d48f0a05187666bca23aac0dad6fe24",
+                "sha256:0d3efb1157edebfd9128e4e46e2ac1a64e0c1fe46fb023158a407c7892b0f8c3",
+                "sha256:0e30e5e67aed0187a1764911af023043b4542e70a7461ad20e837e94d23e1d6c",
+                "sha256:107d53b5c67e0bbc3f03ebf5b030e0403d24dda980f8e244795335ba7b4a027d",
+                "sha256:12fa6ce40cde3f0b899729dbd7d5e8811cb892d31b6f7d0334a1f37748b789fd",
+                "sha256:17a854d9a7a476a89dcef6c8bd119ad23e0f82557afbd2c442777a16408e614f",
+                "sha256:191354ebfe305e84f344c5964c7cd5f924a3bfc5d405c75ad07f232b6dffb49f",
+                "sha256:2ef6630e0ec01376f59a006dc72918b1bf436c3b571b80fa1968d775fa02fe7d",
+                "sha256:3004df1b323d10021fda07a813fd33e0fd57bef0e9a480bb143877f6cba996fe",
+                "sha256:335a420cfd63fc5bc27308e929bee231c15c85cc4c496610ffb17923abf7f231",
+                "sha256:33752b1ba962ee793fa2b6321404bf20011fe45b9afd2a842139de3011898fef",
+                "sha256:3a3fd2204178b6d2adcf09cb4f6426ffef54762577a7c9b54c159008cb288c18",
+                "sha256:3b8d62290ebefd49ee0b3ce7500f5dbdcf13b81402c05f6dafab9a1e1b27212f",
+                "sha256:3e36506d001e93bffe59754397572f21bb5dc7c83f54454c990c74a468cd589e",
+                "sha256:41261d64150858eeb5ff43c753c4b216991e0ae16614a308a15d909503617732",
+                "sha256:50e6e80a4bfd23a25f5c05b90167c19030cf9f87930f7cb2eacb99f45d1c3304",
+                "sha256:531457e5c839d8caea9b589a1bcfe3756b0547d7814e9ce3d437f17da75c32b0",
+                "sha256:55a935b8e9a1d2def0626c4269db3fcd26728cbff1e84f0341465c31c4ee56d8",
+                "sha256:57967b7a28d855313a963aaea51bf6df89f833db4320da458e5b3c5ab6d4c938",
+                "sha256:584027857bc2843772114717a7490a37f68da563b3620f78a849bcb54dc11e62",
+                "sha256:59e1aa0e2cd871b08ca146ed08445038f42ff75968c7ae50d2fdd7860ade2180",
+                "sha256:5bd3cca1f2aa5dbcf39e2aa13dd094ea181f48959e1071265de49cc2b82525af",
+                "sha256:5c1949bf259a388863ced887c7861da1df681cb2388645766c89fdfd9004c669",
+                "sha256:62f26585e8b219cdc909b6a0069efc5e4267e25d4a3770a364ac58024f62a761",
+                "sha256:67a561c4d9fb9465ec866177e7aebcad08fe23aaf6fbd692a6fab69088abfc51",
+                "sha256:6fb1fd3ab08c0cbc6826a2e0447610c6f09e983a281b919ed721ad32236b8b23",
+                "sha256:74a8d21a09f5e025a9a23e7c0fd2c7fe8e7503e4d356c0a2c1486ba010619f09",
+                "sha256:79e70b8342a33b52b55d93b3a59223a844962bef479f6a0ea318ebbcadf71505",
+                "sha256:7a4be4cbf241afee43f1c3969b9103a41b40bcb3a3f467ab19f891d9bc4642e4",
+                "sha256:7c03296b85cb87db865d91da79bf63d5609284fc0cab9472fdd8367bbd830753",
+                "sha256:842d08d75d9fe9fb94b18b071090220697f9f184d4547179b60734846461ed59",
+                "sha256:864f8f19adbe13b7de11ba15d85d4a428c7e2f344bac110f667676a0ff84924b",
+                "sha256:97eea7408db3a5bcce4a55d13245ab3fa566e23b4c67cd227062bb49e26c585d",
+                "sha256:a839320bf27d474e52ef8cb16449bb2ce0ba03ca9f44daba6d93fa1d8828e48a",
+                "sha256:afe327968aaf13fc143a56a3360cb27d4ad0345e34da12c7290f1b00b8fe9a8b",
+                "sha256:b4d4e57f0a63fd0b358eb765063ff661328f69a04494427265950c71b992a39a",
+                "sha256:b6354d3760fcd31994a14c89659dee887f1351a06e5dac3c1142307172a79f90",
+                "sha256:b693dbb82b3c27a1604a3dff5bfc5418a7e6a781bb795288141e5f80cf3a3492",
+                "sha256:bdc6a24e754a555d7316fa4774e64c6c3997d27ed2d1964d55920c7c227bc4ce",
+                "sha256:beeefe437218a65322fbd0069eb437e7c98137e08f22c4660ac2dc795c31f8bb",
+                "sha256:c5eeac541cefd0bb887a371ef73c62c3cd78535e4887b310626036a7c0a817bb",
+                "sha256:c950d682f0952bafcceaf709761da0a32a942272fad381081b51096ffa46cea1",
+                "sha256:d9af79d322e735b1fc33404b5765108ae0ff232d4b54666d46730f8ac1a43676",
+                "sha256:e53e074b120f2877a35cc6c736b8eb161377caae8925c17688bd46ba56daaa5b",
+                "sha256:e965a9c1e9a393b8005031ff52583cedc15b7884fce7deb8b0346388837d6cfe",
+                "sha256:f01e060f14b6b57bbb72fc5b4a83ac21c443c9a2ee708e04a10e9192f90a6281",
+                "sha256:f1e3ffa1365e8702dc48c8b360fef8d7afeca482809c5e45e653af82ccd088c1",
+                "sha256:f6746e6fec103fcd509b96bacdfdaa2fbde9a553245dbada284435173a6f1aef",
+                "sha256:f81b0ed2639568bf14749112298f9e4e2b28853dab50a8b357e31798686a036d"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==4.3.0"
         },
         "billiard": {
             "hashes": [
@@ -414,6 +471,124 @@
             "markers": "python_version >= '3.6'",
             "version": "==0.3.0"
         },
+        "clickhouse-driver": {
+            "hashes": [
+                "sha256:03f31d6e47dc2b0f367f598f5629147ed056d7216c1788e25190fcfbfa02e749",
+                "sha256:05027d32d7cf3e46cb8d04f8c984745ae01bd1bc7b3579f9dadf9b3cca735697",
+                "sha256:050ea4870ead993910b39e7fae965dc1c347b2e8191dcd977cd4b385f9e19f87",
+                "sha256:0819bb63d2c5025a1fb9589f57ef82602687cef11081d6dfa6f2ce44606a1772",
+                "sha256:09049f7e71f15c9c9a03f597f77fc1f7b61ababd155c06c0d9e64d1453d945d7",
+                "sha256:0b9925610d25405a8e6d83ff4f54fc2456a121adb0155999972f5edd6ba3efc8",
+                "sha256:0dc03196a84e32d23b88b665be69afae98f57426f5fdf203e16715b756757961",
+                "sha256:11934bd78d97dd7e1a23a6222b5edd1e1b4d34e1ead5c846dc2b5c56fdc35ff5",
+                "sha256:11b1833ee8ff8d5df39a34a895e060b57bd81e05ea68822bc60476daff4ce1c8",
+                "sha256:125aae7f1308d3083dadbb3c78f828ae492e060f13e4007a0cf53a8169ed7b39",
+                "sha256:153cc03b36f22cbde55aa6a5bbe99072a025567a54c48b262eb0da15d8cd7c83",
+                "sha256:1c26c5ef16d0ef3cabc5bc03e827e01b0a4afb5b4eaf8850b7cf740cee04a1d4",
+                "sha256:1c685cd4abe61af1c26279ff04b9f567eb4d6c1ec7fb265af7481b1f153043aa",
+                "sha256:1f202a58a540c85e47c31dabc8f84b6fe79dca5315c866450a538d58d6fa0571",
+                "sha256:232ee260475611cbf7adb554b81db6b5790b36e634fe2164f4ffcd2ca3e63a71",
+                "sha256:253a3c223b944d691bf0abbd599f592ea3b36f0a71d2526833b1718f37eca5c2",
+                "sha256:25695d78a1d7ad6e221e800612eac08559f6182bf6dee0a220d08de7b612d993",
+                "sha256:275d0ccdab9c3571bdb3e9acfab4497930aa584ff2766b035bb2f854deaf8b82",
+                "sha256:293da77bfcac3168fb35b27c242f97c1a05502435c0686ecbb8e2e4abcb3de26",
+                "sha256:2d982959ff628255808d895a67493f2dab0c3a9bfc65eeda0f00c8ae9962a1b3",
+                "sha256:2ed3dea2d1eca85fef5b8564ddd76dedb15a610c77d55d555b49d9f7c896b64b",
+                "sha256:2f3c4fbb61e75c62a1ab93a1070d362de4cb5682f82833b2c12deccb3bae888d",
+                "sha256:306b3102cba278b5dfec6f5f7dc8b78416c403901510475c74913345b56c9e42",
+                "sha256:367acac95398d721a0a2a6cf87e93638c5588b79498a9848676ce7f182540a6c",
+                "sha256:3d11831842250b4c1b26503a6e9c511fc03db096608b7c6af743818c421a3032",
+                "sha256:3e282c5c25e32d96ed151e5460d2bf4ecb805ea64449197dd918e84e768016df",
+                "sha256:3e51792f3bd12c32cb15a907f12de3c9d264843f0bb33dce400e3966c9f09a3f",
+                "sha256:424153d1d5f5a807f596a48cc88119f9fb3213ca7e38f57b8d15dcc964dd91f7",
+                "sha256:42fc546c31e4a04c97b749769335a679c9044dc693fa7a93e38c97fd6727173d",
+                "sha256:433a650571a0d7766eb6f402e8f5930222997686c2ee01ded22f1d8fd46af9d4",
+                "sha256:457f1d6639e0345b717ae603c79bd087a35361ce68c1c308d154b80b841e5e7d",
+                "sha256:45a3d5b1d06750fd6a18c29b871494a2635670099ec7693e756a5885a4a70dbf",
+                "sha256:471b884d318e012f68d858476052742048918854f7dfe87d78e819f87a848ffb",
+                "sha256:476702740a279744badbd177ae1c4a2d089ec128bd676861219d1f92078e4530",
+                "sha256:48033803abd1100bfff6b9a1769d831b672cd3cda5147e0323b956fd1416d38d",
+                "sha256:49a55aeb8ea625a87965a96e361bbb1ad67d0931bfb2a575f899c1064e70c2da",
+                "sha256:4a8d8e2888a857d8db3d98765a5ad23ab561241feaef68bbffc5a0bd9c142342",
+                "sha256:4f078fd1cf19c4ca63b8d1e0803df665310c8d5b644c5b02bf2465e8d6ef8f55",
+                "sha256:58ee63c35e99da887eb035c8d6d9e64fd298a0efc1460395297dd5cc281a6912",
+                "sha256:5a7353a7a08eee3aa0001d8a5d771cb1f37e2acae1b48178002431f23892121a",
+                "sha256:5cd6d95fab5ff80e9dc9baedc9a926f62f74072d42d5804388d63b63bec0bb63",
+                "sha256:612ca9028c718f362c97f552e63d313cf1a70a616ef8532ddb0effdaf12ebef9",
+                "sha256:653583b1f3b088d106f180d6f02c90917ecd669ec956b62903a05df4a7f44863",
+                "sha256:67d1bf63efb4ba14ae6c6da99622e4a549e68fc3ee14d859bf611d8e6a61b3fa",
+                "sha256:6a383a403d185185c64e49edd6a19b2ec973c5adcb8ebff7ed2fc539a2cc65a5",
+                "sha256:6af1c6cbc3481205503ab72a34aa76d6519249c904aa3f7a84b31e7b435555be",
+                "sha256:6ce04e9d0d0f39561f312d1ac1a8147bc9206e4267e1a23e20e0423ebac95534",
+                "sha256:6dbcee870c60d9835e5dce1456ab6b9d807e6669246357f4b321ef747b90fa43",
+                "sha256:70bee21c245226ad0d637bf470472e2d487b86911b6d673a862127b934336ff4",
+                "sha256:713c498741b54debd3a10a5529e70b6ed85ca33c3e8629e24ae5cd8160b5a5f2",
+                "sha256:730837b8f63941065c9c955c44286aef0987fb084ffb3f55bf1e4fe07df62269",
+                "sha256:7667ab423452754f36ba8fb41e006a46baace9c94e2aca2a745689b9f2753dfb",
+                "sha256:780e42a215d1ae2f6d695d74dd6f087781fb2fa51c508b58f79e68c24c5364e0",
+                "sha256:7ae5c8931bf290b9d85582e7955b9aad7f19ff9954e48caa4f9a180ea4d01078",
+                "sha256:7af871c5315eb829ecf4533c790461ea8f73b3bfd5f533b0467e479fdf6ddcfd",
+                "sha256:7bf51bb761b281d20910b4b689c699ef98027845467daa5bb5dfdb53bd6ee404",
+                "sha256:7e25144219577491929d032a6c3ddd63c6cd7fa764af829a5637f798190d9b26",
+                "sha256:7eaa2ce5ea08cf5fddebb8c274c450e102f329f9e6966b6cd85aa671c48e5552",
+                "sha256:7ef3dd0cbdf2f0171caab90389af0ede068ec802bf46c6a77f14e6edc86671bc",
+                "sha256:81b4b671b785ebb0b8aeabf2432e47072413d81db959eb8cfd8b6ab58c5799c6",
+                "sha256:83a857d99192936091f495826ae97497cd1873af213b1e069d56369fb182ab8e",
+                "sha256:8415ffebd6ca9eef3024763abc450f8659f1716d015bd563c537d01c7fbc3569",
+                "sha256:85d50c011467f5ff6772c4059345968b854b72e07a0219030b7c3f68419eb7f7",
+                "sha256:8798258bd556542dd9c6b8ebe62f9c5110c9dcdf97c57fb077e7b8b6d6da0826",
+                "sha256:8a3195639e6393b9d4aafe736036881ff86b6be5855d4bf7d9f5c31637181ec3",
+                "sha256:8d6c2e5830705e4eeef33070ca4d5a24dfa221f28f2f540e5e6842c26e70b10b",
+                "sha256:909205324089a9ee59bee7ecbfa94595435118cca310fd62efdf13f225aa2965",
+                "sha256:91ec96f2c48e5bdeac9eea43a9bc9cc19acb2d2c59df0a13d5520dfc32457605",
+                "sha256:9230058d8c9b1a04079afae4650fb67745f0f1c39db335728f64d48bd2c19246",
+                "sha256:935e16ebf1a1998d8493979d858821a755503c9b8af572d9c450173d4b88868c",
+                "sha256:93b395c1370629ccce8fb3e14cd5be2646d227bd32018c21f753c543e9a7e96b",
+                "sha256:9aafabc7e32942f85dcb46f007f447ab69024831575df97cae28c6ed127654d1",
+                "sha256:9d577dd4867b9e26cf60590e1f500990c8701a6e3cfbb9e644f4d0c0fb607028",
+                "sha256:9e28f1fe850675e173db586e9f1ac790e8f7edd507a4227cd54cd7445f8e75b6",
+                "sha256:9eed23ea41dd582d76f7a2ec7e09cbe5e9fec008f11a4799fa35ce44a3ebd283",
+                "sha256:9f4e38b2ea09214c8e7848a19391009a18c56a3640e1ba1a606b9e57aeb63404",
+                "sha256:a46b227fab4420566ed24ee70d90076226d16fcf09c6ad4d428717efcf536446",
+                "sha256:a654291132766efa2703058317749d7c69b69f02d89bac75703eaf7f775e20da",
+                "sha256:a6549b53fc5c403dc556cb39b2ae94d73f9b113daa00438a660bb1dd5380ae4d",
+                "sha256:a6cab5cdbb0f8ee51d879d977b78f07068b585225ac656f3c081896c362e8f83",
+                "sha256:ace48db993aa4bd31c42de0fa8d38c94ad47405916d6b61f7a7168a48fb52ac1",
+                "sha256:b07123334fe143bfe6fa4e3d4b732d647d5fd2cfb9ec7f2f76104b46fe9d20c6",
+                "sha256:b243de483cfa02716053b0148d73558f4694f3c27b97fc1eaa97d7079563a14d",
+                "sha256:b57e83d7986d3cbda6096974a9510eb53cb33ad9072288c87c820ba5eee3370e",
+                "sha256:b7a3e6b0a1eb218e3d870a94c76daaf65da46dca8f6888ea6542f94905c24d88",
+                "sha256:b802b6f0fbdcc3ab81b87f09b694dde91ab049f44d1d2c08c3dc8ea9a5950cfa",
+                "sha256:b8ea462e3cebb121ff55002e9c8a9a0a3fd9b5bbbf688b4960f0a83c0172fb31",
+                "sha256:baf57eede88d07a1eb04352d26fc58a4d97991ca3d8840f7c5d48691dec9f251",
+                "sha256:bb05a9bb22cbe9ad187ad268f86adf7e60df6083331fe59c01571b7b725212dd",
+                "sha256:be47e793846aac28442b6b1c6554e0731b848a5a7759a54aa2489997354efe4a",
+                "sha256:c46dccfb04a9afd61a1b0e60bfefceff917f76da2c863f9b36b39248496d5c77",
+                "sha256:cdb1b011a53ee71539e9dc655f268b111bac484db300da92829ed59e910a8fd0",
+                "sha256:ce8e3f4be46bcc63555863f70ab0035202b082b37e6f16876ef50e7bc4b47056",
+                "sha256:de6624e28eeffd01668803d28ae89e3d4e359b1bff8b60e4933e1cb3c6f86f18",
+                "sha256:e2af3efa73d296420ce6362789f5b1febf75d4aa159a479393f01549115509d5",
+                "sha256:e4df50fd84bfa4aa1eb7b52d48136066bfb64fabb7ceb62d4c318b45a296200b",
+                "sha256:e893bd4e014877174a59e032b0e99809c95ec61328a0e6bd9352c74a2f6111a8",
+                "sha256:ed84179914b2b7bb434c2322a6e7fd83daa681c97a050450511b66d917a129bb",
+                "sha256:f05321a97e816afc75b3e4f9eda989848fecf14ecf1a91d0f22c04258123d1f7",
+                "sha256:f138d939e26e767537f891170b69a55a88038919f5c10d8865b67b8777fe4848",
+                "sha256:f6680ee18870bca1fbab1736c8203a965efaec119ab4c37821ad99add248ee08",
+                "sha256:f97f0083194d6e23b5ef6156ed0d5388c37847b298118199d7937ba26412a9e2",
+                "sha256:fcb2fd00e58650ae206a6d5dbc83117240e622471aa5124733fbf2805eb8bda0",
+                "sha256:fffa5a5f317b1ec92e406a30a008929054cf3164d2324a3c465d0a0330273bf8"
+            ],
+            "markers": "python_version >= '3.7' and python_version < '4'",
+            "version": "==0.2.9"
+        },
+        "clickhouse-sqlalchemy": {
+            "hashes": [
+                "sha256:6df4c125db428b856f8a7ec392190d9a4a2bb281eecb4fca2202e9d49ee4d55f"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.6' and python_version < '4'",
+            "version": "==0.2.3"
+        },
         "confusable-homoglyphs": {
             "hashes": [
                 "sha256:84c92cb79dc7f55aa290d0762b2349abd8dee4c16fbe6f99eac978d394e2e6a1",
@@ -423,40 +598,44 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:00918d859aa4e57db8299607086f793fa7813ae2ff5a4637e318a25ef82730f7",
-                "sha256:1e8d181e90a777b63f3f0caa836844a1182f1f265687fac2115fcf245f5fbec3",
-                "sha256:1f9a92144fa0c877117e9748c74501bea842f93d21ee00b0cf922846d9d0b183",
-                "sha256:21377472ca4ada2906bc313168c9dc7b1d7ca417b63c1c3011d0c74b7de9ae69",
-                "sha256:24979e9f2040c953a94bf3c6782e67795a4c260734e5264dceea65c8f4bae64a",
-                "sha256:2a46a89ad3e6176223b632056f321bc7de36b9f9b93b2cc1cccf935a3849dc62",
-                "sha256:322eb03ecc62784536bc173f1483e76747aafeb69c8728df48537eb431cd1911",
-                "sha256:436df4f203482f41aad60ed1813811ac4ab102765ecae7a2bbb1dbb66dcff5a7",
-                "sha256:4f422e8c6a28cf8b7f883eb790695d6d45b0c385a2583073f3cec434cc705e1a",
-                "sha256:53f23339864b617a3dfc2b0ac8d5c432625c80014c25caac9082314e9de56f41",
-                "sha256:5fed5cd6102bb4eb843e3315d2bf25fede494509bddadb81e03a859c1bc17b83",
-                "sha256:610a83540765a8d8ce0f351ce42e26e53e1f774a6efb71eb1b41eb01d01c3d12",
-                "sha256:6c8acf6f3d1f47acb2248ec3ea261171a671f3d9428e34ad0357148d492c7864",
-                "sha256:6f76fdd6fd048576a04c5210d53aa04ca34d2ed63336d4abd306d0cbe298fddf",
-                "sha256:72198e2b5925155497a5a3e8c216c7fb3e64c16ccee11f0e7da272fa93b35c4c",
-                "sha256:887143b9ff6bad2b7570da75a7fe8bbf5f65276365ac259a5d2d5147a73775f2",
-                "sha256:888fcc3fce0c888785a4876ca55f9f43787f4c5c1cc1e2e0da71ad481ff82c5b",
-                "sha256:8e6a85a93d0642bd774460a86513c5d9d80b5c002ca9693e63f6e540f1815ed0",
-                "sha256:94f99f2b943b354a5b6307d7e8d19f5c423a794462bde2bf310c770ba052b1c4",
-                "sha256:9b336599e2cb77b1008cb2ac264b290803ec5e8e89d618a5e978ff5eb6f715d9",
-                "sha256:a2d8a7045e1ab9b9f803f0d9531ead85f90c5f2859e653b61497228b18452008",
-                "sha256:b8272f257cf1cbd3f2e120f14c68bff2b6bdfcc157fafdee84a1b795efd72862",
-                "sha256:bf688f615c29bfe9dfc44312ca470989279f0e94bb9f631f85e3459af8efc009",
-                "sha256:d9c5b9f698a83c8bd71e0f4d3f9f839ef244798e5ffe96febfa9714717db7af7",
-                "sha256:dd7c7e2d71d908dc0f8d2027e1604102140d84b155e658c20e8ad1304317691f",
-                "sha256:df978682c1504fc93b3209de21aeabf2375cb1571d4e61907b3e7a2540e83026",
-                "sha256:e403f7f766ded778ecdb790da786b418a9f2394f36e8cc8b796cc056ab05f44f",
-                "sha256:eb3889330f2a4a148abead555399ec9a32b13b7c8ba969b72d8e500eb7ef84cd",
-                "sha256:f4daefc971c2d1f82f03097dc6f216744a6cd2ac0f04c68fb935ea2ba2a0d420",
-                "sha256:f51f5705ab27898afda1aaa430f34ad90dc117421057782022edf0600bec5f14",
-                "sha256:fd0ee90072861e276b0ff08bd627abec29e32a53b2be44e41dbcdf87cbee2b00"
+                "sha256:04abd71114848aa25edb28e225ab5f268096f44cf0127f3d36975bdf1bdf3390",
+                "sha256:0529b1d5a0105dd3731fa65680b45ce49da4d8115ea76e9da77a875396727b41",
+                "sha256:1bc312dfb7a6e5d66082c87c34c8a62176e684b6fe3d90fcfe1568de675e6688",
+                "sha256:268e4e9b177c76d569e8a145a6939eca9a5fec658c932348598818acf31ae9a5",
+                "sha256:29ecec49f3ba3f3849362854b7253a9f59799e3763b0c9d0826259a88efa02f1",
+                "sha256:2bf7bf75f7df9715f810d1b038870309342bff3069c5bd8c6b96128cb158668d",
+                "sha256:3b721b8b4d948b218c88cb8c45a01793483821e709afe5f622861fc6182b20a7",
+                "sha256:3c00b6b757b32ce0f62c574b78b939afab9eecaf597c4d624caca4f9e71e7843",
+                "sha256:3dc62975e31617badc19a906481deacdeb80b4bb454394b4098e3f2525a488c5",
+                "sha256:4973da6ca3db4405c54cd0b26d328be54c7747e89e284fcff166132eb7bccc9c",
+                "sha256:4e389622b6927d8133f314949a9812972711a111d577a5d1f4bee5e58736b80a",
+                "sha256:51e4de3af4ec3899d6d178a8c005226491c27c4ba84101bfb59c901e10ca9f79",
+                "sha256:5f6f90b72d8ccadb9c6e311c775c8305381db88374c65fa1a68250aa8a9cb3a6",
+                "sha256:6210c05941994290f3f7f175a4a57dbbb2afd9273657614c506d5976db061181",
+                "sha256:6f101b1f780f7fc613d040ca4bdf835c6ef3b00e9bd7125a4255ec574c7916e4",
+                "sha256:7bdcd82189759aba3816d1f729ce42ffded1ac304c151d0a8e89b9996ab863d5",
+                "sha256:7ca25849404be2f8e4b3c59483d9d3c51298a22c1c61a0e84415104dacaf5562",
+                "sha256:81276f0ea79a208d961c433a947029e1a15948966658cf6710bbabb60fcc2639",
+                "sha256:8cadc6e3b5a1f144a039ea08a0bdb03a2a92e19c46be3285123d32029f40a922",
+                "sha256:8e0ddd63e6bf1161800592c71ac794d3fb8001f2caebe0966e77c5234fa9efc3",
+                "sha256:909c97ab43a9c0c0b0ada7a1281430e4e5ec0458e6d9244c0e821bbf152f061d",
+                "sha256:96e7a5e9d6e71f9f4fca8eebfd603f8e86c5225bb18eb621b2c1e50b290a9471",
+                "sha256:9a1e657c0f4ea2a23304ee3f964db058c9e9e635cc7019c4aa21c330755ef6fd",
+                "sha256:9eb9d22b0a5d8fd9925a7764a054dca914000607dff201a24c791ff5c799e1fa",
+                "sha256:af4ff3e388f2fa7bff9f7f2b31b87d5651c45731d3e8cfa0944be43dff5cfbdb",
+                "sha256:b042d2a275c8cee83a4b7ae30c45a15e6a4baa65a179a0ec2d78ebb90e4f6699",
+                "sha256:bc821e161ae88bfe8088d11bb39caf2916562e0a2dc7b6d56714a48b784ef0bb",
+                "sha256:c505d61b6176aaf982c5717ce04e87da5abc9a36a5b39ac03905c4aafe8de7aa",
+                "sha256:c63454aa261a0cf0c5b4718349629793e9e634993538db841165b3df74f37ec0",
+                "sha256:c7362add18b416b69d58c910caa217f980c5ef39b23a38a0880dfd87bdf8cd23",
+                "sha256:d03806036b4f89e3b13b6218fefea8d5312e450935b1a2d55f0524e2ed7c59d9",
+                "sha256:d1b3031093a366ac767b3feb8bcddb596671b3aaff82d4050f984da0c248b615",
+                "sha256:d1c3572526997b36f245a96a2b1713bf79ce99b271bbcf084beb6b9b075f29ea",
+                "sha256:efcfe97d1b3c79e486554efddeb8f6f53a4cdd4cf6086642784fa31fc384e1d7",
+                "sha256:f514ef4cd14bb6fb484b4a60203e912cfcb64f2ab139e88c2274511514bf7308"
             ],
             "markers": "python_version >= '3.7' and python_full_version not in '3.9.0, 3.9.1'",
-            "version": "==44.0.1"
+            "version": "==44.0.2"
         },
         "cssselect2": {
             "hashes": [
@@ -987,6 +1166,14 @@
             "markers": "python_version >= '3.8'",
             "version": "==1.5.3"
         },
+        "paramiko": {
+            "hashes": [
+                "sha256:43b9a0501fc2b5e70680388d9346cf252cfb7d00b0667c39e80eb43a408b8f61",
+                "sha256:b2c665bc45b2b215bd7d7f039901b14b067da00f3a11e6640995fd58f2664822"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==3.5.1"
+        },
         "pillow": {
             "hashes": [
                 "sha256:015c6e863faa4779251436db398ae75051469f7c903b043a48f078e437656f83",
@@ -1179,6 +1366,22 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==0.11.0"
+        },
+        "pynacl": {
+            "hashes": [
+                "sha256:06b8f6fa7f5de8d5d2f7573fe8c863c051225a27b61e6860fd047b1775807858",
+                "sha256:0c84947a22519e013607c9be43706dd42513f9e6ae5d39d3613ca1e142fba44d",
+                "sha256:20f42270d27e1b6a29f54032090b972d97f0a1b0948cc52392041ef7831fee93",
+                "sha256:401002a4aaa07c9414132aaed7f6836ff98f59277a234704ff66878c2ee4a0d1",
+                "sha256:52cb72a79269189d4e0dc537556f4740f7f0a9ec41c1322598799b0bdad4ef92",
+                "sha256:61f642bf2378713e2c2e1de73444a3778e5f0a38be6fee0fe532fe30060282ff",
+                "sha256:8ac7448f09ab85811607bdd21ec2464495ac8b7c66d146bf545b0f08fb9220ba",
+                "sha256:a36d4a9dda1f19ce6e03c9a784a2921a4b726b02e1c736600ca9c22029474394",
+                "sha256:a422368fc821589c228f4c49438a368831cb5bbc0eab5ebe1d7fac9dded6567b",
+                "sha256:e46dae94e34b085175f8abb3b0aaa7da40767865ac82c928eeb9e57e1ea8a543"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.5.0"
         },
         "pyogrio": {
             "hashes": [
@@ -1445,6 +1648,15 @@
             "markers": "python_version >= '3.8'",
             "version": "==0.5.3"
         },
+        "sshtunnel": {
+            "hashes": [
+                "sha256:4a07cf989712e8ba76a370584bec922d14775054b3ff18e5d075507a298dc3ed",
+                "sha256:98e54c26f726ab8bd42b47a3a21fca5c3e60f58956f0f70de2fb8ab0046d0606",
+                "sha256:e7cb0ea774db81bf91844db22de72a40aae8f7b0f9bb9ba0f666d474ef6bf9fc"
+            ],
+            "index": "pypi",
+            "version": "==0.4.0"
+        },
         "tablib": {
             "extras": [
                 "xlsx"
@@ -1485,7 +1697,7 @@
                 "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
                 "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"
             ],
-            "markers": "python_version < '3.13'",
+            "markers": "python_version >= '3.8'",
             "version": "==4.12.2"
         },
         "tzdata": {
@@ -1495,6 +1707,14 @@
             ],
             "markers": "python_version >= '2'",
             "version": "==2025.1"
+        },
+        "tzlocal": {
+            "hashes": [
+                "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd",
+                "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==5.3.1"
         },
         "urllib3": {
             "hashes": [

--- a/src/config/settings/base.py
+++ b/src/config/settings/base.py
@@ -101,7 +101,18 @@ DATABASES = {
     "default": env.db(),
 }
 
-WAREHOUSE_URL = env("WAREHOUSE_URL")
+DWH_USERNAME = env.str("DWH_USERNAME")
+DWH_PASSWORD = env.str("DWH_PASSWORD")
+DWH_PORT = env.str("DWH_PORT")
+DWH_SSH_HOST = env.str("DWH_SSH_HOST")
+DWH_SSH_PORT = env.str("DWH_SSH_PORT")
+DWH_SSH_USERNAME = env.str("DWH_SSH_USERNAME")
+DWH_SSH_LOCAL_BIND_HOST = env.str("DWH_SSH_LOCAL_BIND_HOST")
+DWH_SSH_LOCAL_BIND_PORT = env.str("DWH_SSH_LOCAL_BIND_PORT")
+DWH_SSH_KEY = env.str("DWH_SSH_KEY", multiline=True)
+WAREHOUSE_URL = (
+    f"clickhouse+native://{DWH_USERNAME}:{DWH_PASSWORD}@{DWH_SSH_LOCAL_BIND_HOST}:{DWH_SSH_LOCAL_BIND_PORT}"
+)
 
 # Password validation
 # https://docs.djangoproject.com/en/4.1/ref/settings/#auth-password-validators

--- a/src/config/settings/production.py
+++ b/src/config/settings/production.py
@@ -41,4 +41,3 @@ SENTRY_URL = env("SENTRY_URL")
 sentry_sdk.init(SENTRY_URL, traces_sample_rate=1.0)
 
 DJANGO_VITE = {"default": {"dev_mode": False, "static_url_prefix": "ui_app/dist"}}
-

--- a/src/config/settings/production.py
+++ b/src/config/settings/production.py
@@ -41,3 +41,4 @@ SENTRY_URL = env("SENTRY_URL")
 sentry_sdk.init(SENTRY_URL, traces_sample_rate=1.0)
 
 DJANGO_VITE = {"default": {"dev_mode": False, "static_url_prefix": "ui_app/dist"}}
+

--- a/src/maps/management/commands/retrieve_companies.py
+++ b/src/maps/management/commands/retrieve_companies.py
@@ -1,15 +1,11 @@
+import pandas as pd
 from django.conf import settings
 from django.core.management.base import BaseCommand
-from sqlalchemy import create_engine
-from sqlalchemy.sql import text
-import pandas as pd
 
 from sheets.database import build_query
 from sheets.ssh import ssh_tunnel
 
 from ...models import CartoCompany
-
-wh_engine = create_engine(settings.WAREHOUSE_URL, pool_pre_ping=True)
 
 BATCH_SIZE = 10000
 query = """

--- a/src/maps/models.py
+++ b/src/maps/models.py
@@ -41,8 +41,8 @@ class CartoCompany(models.Model):
 
     latitude_td = models.DecimalField(max_digits=20, decimal_places=10, null=True, blank=True)
     longitude_td = models.DecimalField(max_digits=20, decimal_places=10, null=True, blank=True)
-    latitude_ban = models.FloatField(null=True, blank=True)
-    longitude_ban = models.FloatField(null=True, blank=True)
+    latitude_ban = models.DecimalField(max_digits=20, decimal_places=10, null=True, blank=True)
+    longitude_ban = models.DecimalField(max_digits=20, decimal_places=10, null=True, blank=True)
 
     coords = models.PointField(null=True, blank=True)
 

--- a/src/sheets/data_processing.py
+++ b/src/sheets/data_processing.py
@@ -1,4 +1,6 @@
+import time
 from typing import Dict, List, Tuple
+import logging
 
 import pandas as pd
 from django.utils import timezone
@@ -91,6 +93,8 @@ WASTE_CODES_DATA = load_waste_code_data()
 DEPARTEMENTS_REGION_DATA = load_departements_regions_data()
 REGIONS_GEODATA = load_and_preprocess_regions_geographical_data()
 PROCESSING_OPERATION_CODE_RUBRIQUE_MAPPING = load_mapping_rubrique_processing_operation_code()
+
+logger = logging.getLogger(__name__)
 
 
 def get_outliers_datetimes_df(
@@ -200,12 +204,17 @@ class SheetProcessor:
         self.gistrid_data = None
 
     def _extract_data(self):
+        start_time = time.time()
+
         with ssh_tunnel(settings):
             self._extract_company_data()
             self._extract_trackdechets_data()
             self._extract_icpe_data()
             self._extract_rndts_data()
             self._extract_gistrid_data()
+
+        end_time = time.time() - start_time
+        logger.info("Data extracted in %ss", end_time)
 
     def _extract_company_data(self):
         company_data_df = build_query_company(siret=self.siret, date_params=["created_at"])

--- a/src/sheets/data_processing.py
+++ b/src/sheets/data_processing.py
@@ -1,10 +1,10 @@
+import logging
 import time
 from typing import Dict, List, Tuple
-import logging
 
 import pandas as pd
-from django.utils import timezone
 from django.conf import settings
+from django.utils import timezone
 
 from sheets.ssh import ssh_tunnel
 

--- a/src/sheets/database.py
+++ b/src/sheets/database.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from sqlalchemy import create_engine
 from sqlalchemy.sql import text
 
-from .ssh import ssh_tunnel
+
 from .queries import (
     sql_bsda_query_str,
     sql_bsda_transporter_query_str,
@@ -41,7 +41,7 @@ from .queries import (
 
 wh_engine = create_engine(settings.WAREHOUSE_URL)
 
-bsd_date_params = ["created_at", "sent_at", "received_at", "processed_at", "worker_work_signature_date"]
+bsd_date_params = ["created_at", "updated_at", "sent_at", "received_at", "processed_at", "worker_work_signature_date"]
 
 bs_dtypes = {
     "id": str,
@@ -68,13 +68,12 @@ def build_query(
 ):
     query = text(query_str)
 
-    with ssh_tunnel(settings):
-        df = pd.read_sql_query(
-            query,
-            params=query_params,
-            con=wh_engine,
-            dtype=dtypes,
-        )
+    df = pd.read_sql_query(
+        query,
+        params=query_params,
+        con=wh_engine,
+        dtype=dtypes,
+    )
 
     if date_columns is not None:
         for col in date_columns:

--- a/src/sheets/database.py
+++ b/src/sheets/database.py
@@ -7,7 +7,6 @@ from django.conf import settings
 from sqlalchemy import create_engine
 from sqlalchemy.sql import text
 
-
 from .queries import (
     sql_bsda_query_str,
     sql_bsda_transporter_query_str,

--- a/src/sheets/forms.py
+++ b/src/sheets/forms.py
@@ -2,11 +2,11 @@ import datetime as dt
 import os
 import tempfile
 
+import sshtunnel
 from django.conf import settings
 from django.forms import CharField, DateField, Form, ValidationError
 from django.forms.widgets import DateInput
 from sqlalchemy.sql import text
-import sshtunnel
 
 from .database import wh_engine
 from .queries import sql_company_query_exists_str

--- a/src/sheets/queries.py
+++ b/src/sheets/queries.py
@@ -41,9 +41,9 @@ where
     or recipient_company_siret = :siret
     or eco_organisme_siret = :siret
     )
-    and is_deleted = false
+    and not is_deleted
     and status::text not in ('DRAFT', 'INITIAL')
-    and (waste_details_code ~* '.*\*$' or waste_details_pop or waste_details_is_dangerous)
+    and (match(waste_details_code,'(?i).*\*$') or waste_details_pop or waste_details_is_dangerous)
     -- to avoid pandas datetime overflow
     and (
 		sent_at between '1677-09-22' and '2262-04-11'
@@ -101,9 +101,9 @@ where
     (emitter_company_siret = :siret
     or recipient_company_siret = :siret
     or eco_organisme_siret = :siret)
-    and is_deleted = false
+    and not is_deleted
     and status::text not in ('DRAFT', 'INITIAL')
-    and not (waste_details_code ~* '.*\*$' or waste_details_pop or waste_details_is_dangerous)
+    and not (match(waste_details_code,'(?i).*\*$') or waste_details_pop or waste_details_is_dangerous)
     -- to avoid pandas datetime overflow
     and (
 		sent_at between '1677-09-22' and '2262-04-11'
@@ -253,7 +253,7 @@ where
         or worker_company_siret = :siret
         or eco_organisme_siret = :siret    
     )
-    and is_deleted = false
+    and not is_deleted
     and status::text not in ('DRAFT', 'INITIAL')
     and not is_draft
     -- to avoid pandas datetime overflow
@@ -330,7 +330,7 @@ where
         or transporter_company_siret = :siret
         or eco_organisme_siret = :siret
         )
-    and is_deleted = false
+    and not is_deleted
     and status::text not in ('DRAFT', 'INITIAL')
     and not is_draft
     -- to avoid pandas datetime overflow
@@ -361,16 +361,11 @@ from
     trusted_zone_trackdechets.bsff
 where
     (emitter_company_siret = :siret
-        or destination_company_siret = :siret
-        or transporter_company_siret = :siret)
-    and is_deleted = false
+        or destination_company_siret = :siret)
+    and not is_deleted
     and status::text not in ('DRAFT', 'INITIAL')
     and not is_draft
     -- to avoid pandas datetime overflow
-    and (
-		transporter_transport_taken_over_at between '1677-09-22' and '2262-04-11'
-		or transporter_transport_taken_over_at is null
-	)
     and (
 		destination_reception_date between '1677-09-22' and '2262-04-11'
 		or destination_reception_date is null
@@ -399,7 +394,7 @@ where
     where
         (emitter_company_siret = :siret
             or destination_company_siret = :siret)
-        and is_deleted = false
+        and not is_deleted
         and status::text not in ('DRAFT', 'INITIAL')
             and not is_draft
 )
@@ -452,7 +447,7 @@ where
     (emitter_company_siret = :siret
         or destination_company_siret = :siret
         or transporter_company_siret = :siret)
-    and is_deleted = false
+    and not is_deleted
     and  status::text not in ('DRAFT', 'INITIAL')
     and not is_draft
     -- to avoid pandas datetime overflow
@@ -576,7 +571,7 @@ select
 from
     trusted_zone_trackdechets.company c
 where
-    substring(c.siret for 9) = substring(:siret for 9)
+    substring(c.siret,1,9) = substring(:siret,1,9)
 """
 
 sql_get_gistrid_data = """
@@ -616,7 +611,7 @@ SELECT
 FROM trusted_zone_rndts.dnd_entrant
 where
     etablissement_numero_identification = :siret
-    or (numeros_indentification_transporteurs @> array[:siret])
+    or has(numeros_indentification_transporteurs,:siret)
 """
 
 sql_get_outgoing_ndw_data = """
@@ -635,7 +630,7 @@ SELECT
 FROM trusted_zone_rndts.dnd_sortant
 where
     producteur_numero_identification = :siret
-    or (numeros_indentification_transporteurs @> array[:siret])
+    or has(numeros_indentification_transporteurs,:siret)
 """
 
 
@@ -653,7 +648,7 @@ SELECT
 FROM trusted_zone_rndts.texs_entrant
 where
     etablissement_numero_identification = :siret
-    or (numeros_indentification_transporteurs @> array[:siret])
+    or has(numeros_indentification_transporteurs,:siret)
 """
 
 sql_get_outgoing_excavated_land_data = """
@@ -672,7 +667,7 @@ SELECT
 FROM trusted_zone_rndts.texs_sortant
 where
     producteur_numero_identification = :siret
-    or (numeros_indentification_transporteurs @> array[:siret])
+    or has(numeros_indentification_transporteurs,:siret)
 """
 
 sql_get_ssd_data = """
@@ -699,5 +694,5 @@ select
  from
     trusted_zone_trackdechets.company
 where
-    siret = :siret ;
+    siret = :siret
 """

--- a/src/sheets/ssh.py
+++ b/src/sheets/ssh.py
@@ -1,7 +1,8 @@
-import tempfile
 import os
-import sshtunnel
+import tempfile
 from contextlib import contextmanager
+
+import sshtunnel
 
 
 @contextmanager

--- a/src/sheets/ssh.py
+++ b/src/sheets/ssh.py
@@ -1,0 +1,27 @@
+import tempfile
+import os
+import sshtunnel
+from contextlib import contextmanager
+
+
+@contextmanager
+def ssh_tunnel(settings):
+    temp_key_file = tempfile.NamedTemporaryFile(mode="w", delete=False)
+    try:
+        temp_key_file.write(settings.DWH_SSH_KEY)
+        temp_key_file.close()
+        os.chmod(temp_key_file.name, 0o600)
+
+        tunnel = sshtunnel.open_tunnel(
+            (settings.DWH_SSH_HOST, int(settings.DWH_SSH_PORT)),
+            ssh_username=settings.DWH_SSH_USERNAME,
+            ssh_pkey=temp_key_file.name,
+            remote_bind_address=("localhost", int(settings.DWH_PORT)),
+            local_bind_address=(settings.DWH_SSH_LOCAL_BIND_HOST, int(settings.DWH_SSH_LOCAL_BIND_PORT)),
+        )
+
+        tunnel.start()
+        yield tunnel
+    finally:
+        tunnel.stop()
+        os.unlink(temp_key_file.name)

--- a/src/sheets/tests/test_icpe_annual_item_processor.py
+++ b/src/sheets/tests/test_icpe_annual_item_processor.py
@@ -163,9 +163,9 @@ def test_zero_processed_quantities():
 
     processor._preprocess_data()
 
-    assert processor._check_data_empty(), (
-        "Data should be considered empty when all rows have zero processed quantities."
-    )
+    assert (
+        processor._check_data_empty()
+    ), "Data should be considered empty when all rows have zero processed quantities."
 
 
 def test_only_nan_processed_quantities():


### PR DESCRIPTION
Cette PR migre la source des données de la fiche Vers le DWHv2 Clickhouse. Celui-ci n'étant pas directement exposé à internet, un tunnel SSH est ouvert avant chaque extraction de données d'un établissement.

L'extraction des données nécessaires à la cartographie des établissements a été également migrée.

- [ ] Mettre à jour le change log
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/37a331c647a38a191b2a1207?card=tra-16149)
