### PR TITLE
Corrige un paramètre manquant pour le workerapi dans le procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -6,4 +6,4 @@ web: gunicorn --chdir src config.wsgi:application --log-file - --timeout 120
 
 # Run celery worker
 workerweb: celery --workdir src -A config worker -Q web-queue -l info --pool threads
-workerapi: celery --workdir src -A config worker -Q api-queue -l info
+workerapi: celery --workdir src -A config worker -Q api-queue -l info --pool threads


### PR DESCRIPTION
Le paramètre `--pool threads` était manquant est crée des problèmes en prod.


- [ ] Mettre à jour le change log
---

- [Ticket Favro]()
