### PR TITLE
 Rendre l'affichage des graphes ICPE dynamique

### DIFF
--- a/src/sheets/templatetags/graph_tags.py
+++ b/src/sheets/templatetags/graph_tags.py
@@ -1,5 +1,3 @@
-import re
-
 from django import template
 
 register = template.Library()
@@ -252,20 +250,19 @@ def render_icpe_graphs(computed, graph_context="web"):
 def has_rubrique(rubrique_to_search: str, icpe_rubriques_items: list[dict]) -> bool:
     for rubrique_item in icpe_rubriques_items:
         rubrique_available = rubrique_item["rubrique"]
-
-        rubrique_cleaned = ""
-        if (
-            re.match(r"^2760-[1,2].*", rubrique_available) is not None
-        ):  # Handle the cases 2760-1, 27-60-2-7, 2760-2-b...
-            rubrique_cleaned = rubrique_available[:6]
-        elif rubrique_available.startswith("2791"):  # Handle the cases 2791-*
-            rubrique_cleaned = rubrique_available[:4]
-        elif rubrique_available in ["2770", "2790", "2771"]:
-            rubrique_cleaned = rubrique_available
-        else:
-            continue
-
-        if rubrique_to_search == rubrique_cleaned:
+        rubrique_available_cleaned = get_cleaned_rubrique(rubrique_available)
+        if rubrique_to_search == rubrique_available_cleaned:
             return True
 
     return False
+
+
+def get_cleaned_rubrique(rubrique_str: str) -> str:
+    rubrique_mapping = {
+        "2791-1": "2791",
+        "2791-2": "2791",
+        "2760-2-a": "2760-2",
+        "2760-2-b": "2760-2",
+    }
+
+    return rubrique_mapping.get(rubrique_str, rubrique_str)

--- a/src/sheets/templatetags/graph_tags.py
+++ b/src/sheets/templatetags/graph_tags.py
@@ -217,21 +217,20 @@ def render_incinerator_outgoing_waste_table(computed, graph_context="web"):
 
 @register.inclusion_tag("sheets/components/icpe_graphs.html")
 def render_icpe_graphs(computed, graph_context="web"):
-    attributes = [
-        "icpe_2760_1_data",
-        "icpe_2770_data",
-        "icpe_2790_data",
-        "icpe_2760_2_data",
-        "icpe_2771_data",
-        "icpe_2791_data",
-    ]
+    attributes = {
+        "icpe_2760_1_data": "2760_1",
+        "icpe_2770_data": "2770",
+        "icpe_2790_data": "2790",
+        "icpe_2760_2_data": "2760_2",
+        "icpe_2771_data": "2771",
+        "icpe_2791_data": "2791",
+    }
 
     rubriques_data = []
 
     icpe_rubriques_items = computed.icpe_data
 
-    for attribute in attributes:
-        rubrique = attribute[5:-5].replace("_", "-")
+    for attribute, rubrique in attributes.items():
         icpe_data = getattr(computed, attribute)
         if ((icpe_data is None) or (icpe_data in ["", "{}"])) and not has_rubrique(rubrique, icpe_rubriques_items):
             continue

--- a/src/templates/sheets/components/icpe_graphs.html
+++ b/src/templates/sheets/components/icpe_graphs.html
@@ -1,0 +1,17 @@
+{% for rubrique_data in rubriques_data %}
+    <div class="row">
+        <div class="cell cell--bordered cell--full">
+            <h3 class="cell__title">Données relatives à la rubrique {{ rubrique_data.icpe_rubrique }}</h3>
+            <p class="fr-tag fr-tag fr-icon-info-fill fr-tag--icon-left">
+                Source : {{ rubrique_data.data_source }}
+            </p>
+            <div id="icpe-{{ rubrique_data.icpe_rubrique }}-graph">
+                {% if rubrique_data.graph_data %}
+                    <img src="data:image/png;base64,{{ rubrique_data.graph_data }}" class="cell__img">
+                {% else %}
+                    <div class="no-data">Pas de données à afficher.</div>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+{% endfor %}

--- a/src/templates/sheets/sheet.html
+++ b/src/templates/sheets/sheet.html
@@ -375,60 +375,7 @@
                 En cas de différence avec la réalité, merci de vérifier et mettre à jour GUN,
                 de façon à pouvoir vous proposer une analyse plus fine en lien avec les rubriques.
             </p>
-            <div class="row">
-                <div class="cell cell--bordered cell--full">
-                    <h3 class="cell__title">Données relatives à la rubrique 2760-1</h3>
-                    <p class="fr-tag fr-tag fr-icon-info-fill fr-tag--icon-left">Source : Trackdéchets</p>
-                    <div id="icpe_2760_1_graph">
-                        <div class="no-data">Pas de données à afficher.</div>
-                    </div>
-                </div>
-            </div>
-            <div class="row">
-                <div class="cell cell--bordered cell--full">
-                    <h3 class="cell__title">Données relatives à la rubrique 2760-2</h3>
-                    <p class="fr-tag fr-tag fr-icon-info-fill fr-tag--icon-left">Source : RNDTS</p>
-                    <div id="icpe_2760_2_graph">
-                        <div class="no-data">Pas de données à afficher.</div>
-                    </div>
-                </div>
-            </div>
-            <div class="row">
-                <div class="cell cell--bordered cell--full">
-                    <h3 class="cell__title">Données relatives à la rubrique 2770</h3>
-                    <p class="fr-tag fr-tag fr-icon-info-fill fr-tag--icon-left">Source : Trackdéchets</p>
-                    <div id="icpe_2770_graph">
-                        <div class="no-data">Pas de données à afficher.</div>
-                    </div>
-                </div>
-            </div>
-            <div class="row">
-                <div class="cell cell--bordered cell--full">
-                    <h3 class="cell__title">Données relatives à la rubrique 2771</h3>
-                    <p class="fr-tag fr-tag fr-icon-info-fill fr-tag--icon-left">Source : RNDTS</p>
-                    <div id="icpe_2771_graph">
-                        <div class="no-data">Pas de données à afficher.</div>
-                    </div>
-                </div>
-            </div>
-            <div class="row">
-                <div class="cell cell--bordered cell--full">
-                    <h3 class="cell__title">Données relatives à la rubrique 2790</h3>
-                    <p class="fr-tag fr-tag fr-icon-info-fill fr-tag--icon-left">Source : Trackdéchets</p>
-                    <div id="icpe_2790_graph">
-                        <div class="no-data">Pas de données à afficher.</div>
-                    </div>
-                </div>
-            </div>
-            <div class="row">
-                <div class="cell cell--bordered cell--full">
-                    <h3 class="cell__title">Données relatives à la rubrique 2791</h3>
-                    <p class="fr-tag fr-tag fr-icon-info-fill fr-tag--icon-left">Source : RNDTS</p>
-                    <div id="icpe_2791_graph">
-                        <div class="no-data">Pas de données à afficher.</div>
-                    </div>
-                </div>
-            </div>
+            {% render_icpe_graphs sheet %}
             {% if sheet.bs_processed_without_icpe_authorization.dangerous or sheet.bs_processed_without_icpe_authorization.non_dangerous %}
                 <div class="row">
                     <div class="cell cell--bordered cell--full">
@@ -615,27 +562,27 @@
     },
     {
         "data": icpe_2770_data,
-        "target": "icpe_2770_graph"
+        "target": "icpe-2770-graph"
     },
     {
         "data": icpe_2790_data,
-        "target": "icpe_2790_graph"
+        "target": "icpe-2790-graph"
     },
     {
         "data": icpe_2760_1_data,
-        "target": "icpe_2760_1_graph"
+        "target": "icpe-2760-1-graph"
     },
     {
         "data": icpe_2771_data,
-        "target": "icpe_2771_graph"
+        "target": "icpe-2771-graph"
     },
     {
         "data": icpe_2791_data,
-        "target": "icpe_2791_graph"
+        "target": "icpe-2791-graph"
     },
     {
         "data": icpe_2760_2_data,
-        "target": "icpe_2760_2_graph"
+        "target": "icpe-2760-2-graph"
     },
     {
         "data": bsda_worker_quantity_data,

--- a/src/templates/sheets/sheetpdf.html
+++ b/src/templates/sheets/sheetpdf.html
@@ -355,72 +355,7 @@
                     En cas de différence avec la réalité, merci de vérifier et mettre à jour GUN,
                     de façon à pouvoir vous proposer une analyse plus fine en lien avec les rubriques.
                 </p>
-                <div class="row">
-                    <div class="cell cell--bordered cell--full">
-                        <h3 class="cell__title">Données relatives à la rubrique 2760-1</h3>
-                        <p class="fr-tag fr-tag fr-icon-info-fill fr-tag--icon-left">Source : Trackdéchets</p>
-                        {% if icpe_2760_graph %}
-                            <img src="data:image/png;base64,{{ icpe_2760_1_graph }}" class="cell__img">
-                        {% else %}
-                            <div class="no-data">Pas de données à afficher.</div>
-                        {% endif %}
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="cell cell--bordered cell--full">
-                        <h3 class="cell__title">Données relatives à la rubrique 2760-2</h3>
-                        <p class="fr-tag fr-tag fr-icon-info-fill fr-tag--icon-left">Source : RNDTS</p>
-                        {% if icpe_2760_2_graph %}
-                            <img src="data:image/png;base64,{{ icpe_2760_2_graph }}" class="cell__img">
-                        {% else %}
-                            <div class="no-data">Pas de données à afficher.</div>
-                        {% endif %}
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="cell cell--bordered cell--full">
-                        <h3 class="cell__title">Données relatives à la rubrique 2770</h3>
-                        <p class="fr-tag fr-tag fr-icon-info-fill fr-tag--icon-left">Source : Trackdéchets</p>
-                        {% if icpe_2770_graph %}
-                            <img src="data:image/png;base64,{{ icpe_2770_graph }}" class="cell__img">
-                        {% else %}
-                            <div class="no-data">Pas de données à afficher.</div>
-                        {% endif %}
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="cell cell--bordered cell--full">
-                        <h3 class="cell__title">Données relatives à la rubrique 2771</h3>
-                        <p class="fr-tag fr-tag fr-icon-info-fill fr-tag--icon-left">Source : RNDTS</p>
-                        {% if icpe_2771_graph %}
-                            <img src="data:image/png;base64,{{ icpe_2771_graph }}" class="cell__img">
-                        {% else %}
-                            <div class="no-data">Pas de données à afficher.</div>
-                        {% endif %}
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="cell cell--bordered cell--full">
-                        <h3 class="cell__title">Données relatives à la rubrique 2790</h3>
-                        <p class="fr-tag fr-tag fr-icon-info-fill fr-tag--icon-left">Source : Trackdéchets</p>
-                        {% if icpe_2790_graph %}
-                            <img src="data:image/png;base64,{{ icpe_2790_graph }}" class="cell__img">
-                        {% else %}
-                            <div class="no-data">Pas de données à afficher.</div>
-                        {% endif %}
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="cell cell--bordered cell--full">
-                        <h3 class="cell__title">Données relatives à la rubrique 2791</h3>
-                        <p class="fr-tag fr-tag fr-icon-info-fill fr-tag--icon-left">Source : RNDTS</p>
-                        {% if icpe_2791_graph %}
-                            <img src="data:image/png;base64,{{ icpe_2791_graph }}" class="cell__img">
-                        {% else %}
-                            <div class="no-data">Pas de données à afficher.</div>
-                        {% endif %}
-                    </div>
-                </div>
+                {% render_icpe_graphs sheet graph_context="pdf" %}
                 {% if sheet.bs_processed_without_icpe_authorization %}
                     <div class="row">
                         <div>


### PR DESCRIPTION
Avant touts les blocs de graphes ICPE s'affichaient pour chaque fiche.
Avec cette PR, l'affichage du bloc n'est activé que si l'établissement a la rubrique qui correspond.

- [ ] Mettre à jour le change log
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/37a331c647a38a191b2a1207?card=tra-16162)
