### PR TITLE
Ajout de l'objectif de quantité traitée pour 2025 pour les installations 2760-2

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,10 @@ Les changements importants de Trackdéchets préparation inspection sont documen
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versioning inspiré de [Calendar Versioning](https://calver.org/).
 
+## 22/04/2025
+
+- Ajout de l'objectif de quantité traitée pour les installations 2760-2
+
 ## 15/04/2025
 
 - Téléchargement des établissements sélectionnés sur la cartographie

--- a/src/sheets/graph_processors/plotly_components_processors.py
+++ b/src/sheets/graph_processors/plotly_components_processors.py
@@ -909,7 +909,9 @@ class ICPEDailyItemProcessor:
 
 
 class ICPEAnnualItemProcessor:
-    """Component with a figure representing the cummulative quantity of waste processed by day for a particular ICPE "rubrique".
+    """
+    Component with a figure representing the cummulative quantity of waste processed by day
+    for a particular ICPE "rubrique".
 
 
     Parameters:
@@ -926,6 +928,7 @@ class ICPEAnnualItemProcessor:
 
         self.preprocessed_df = None
         self.authorized_quantity = None
+        self.target_quantity = None
 
         self.figure = None
 
@@ -942,6 +945,7 @@ class ICPEAnnualItemProcessor:
 
         self.preprocessed_df = final_df
         self.authorized_quantity = self.icpe_item_daily_data["authorized_quantity"].max()
+        self.target_quantity = self.icpe_item_daily_data["target_quantity"].max()
 
     def _check_data_empty(self) -> bool:
         if (self.preprocessed_df is None) or len(self.preprocessed_df) == 0:
@@ -1012,10 +1016,11 @@ class ICPEAnnualItemProcessor:
                 font_size=13,
             )
 
-            if authorized_quantity > 0:
+            target_quantity = self.target_quantity
+            if target_quantity is not None:
                 # Target for 2025
                 fig.add_hline(
-                    y=authorized_quantity / 2,
+                    y=target_quantity,
                     line_dash="dot",
                     line_color="black",
                     line_width=2,
@@ -1024,8 +1029,8 @@ class ICPEAnnualItemProcessor:
                     xref="x domain",
                     yref="y",
                     x=0.7,
-                    y=authorized_quantity / 2,
-                    text=f"Objectif 50% pour 2025 : <b>{format_number_str(authorized_quantity / 2, 2)}</b> t/an",
+                    y=target_quantity,
+                    text=f"Objectif pour 2025 : <b>{format_number_str(target_quantity, 2)}</b> t/an",
                     font_color="black",
                     xanchor="left",
                     yanchor="bottom",

--- a/src/sheets/queries.py
+++ b/src/sheets/queries.py
@@ -553,7 +553,8 @@ sql_get_icpe_item_data = """
 SELECT
     day_of_processing,
     quantite_traitee AS processed_quantity,
-    quantite_autorisee AS authorized_quantity
+    quantite_autorisee AS authorized_quantity,
+    objectif_quantite_traitee AS target_quantity
 FROM
     refined_zone_icpe.installations_daily_processed_wastes
 WHERE

--- a/src/sheets/tests/test_icpe_annual_item_processor.py
+++ b/src/sheets/tests/test_icpe_annual_item_processor.py
@@ -26,6 +26,7 @@ def sample_icpe_data():
         ],
         "processed_quantity": [10, 20, 15, 0, 5, 0, 25, 30, 0, 5],
         "authorized_quantity": [50, 50, 50, 50, 50, 50, 50, 50, 50, 50],
+        "target_quantity": [25, 25, 25, 25, 25, 25, 25, 25, 25, 25],
     }
 
     return pd.DataFrame(data)
@@ -153,6 +154,7 @@ def test_zero_processed_quantities():
         "day_of_processing": [datetime(2023, 1, 1), datetime(2023, 1, 2), datetime(2023, 1, 3)],
         "processed_quantity": [0, 0, 0],
         "authorized_quantity": [50, 50, 50],
+        "target_quantity": [25, 25, 25],
     }
 
     icpe_data_df = pd.DataFrame(data)
@@ -171,6 +173,7 @@ def test_only_nan_processed_quantities():
         "day_of_processing": [datetime(2023, 1, 1), datetime(2023, 1, 2), datetime(2023, 1, 3)],
         "processed_quantity": [float("nan"), float("nan"), float("nan")],
         "authorized_quantity": [50, 50, 50],
+        "target_quantity": [25, 25, 25],
     }
 
     icpe_data_df = pd.DataFrame(data)


### PR DESCRIPTION
Jusqu'à présent l'objectif de quantité traitée était égal à la moitié de la quantité autorisée. Dorénavant il est basé sur une valeur que l'administration nous fournit.
![Capture d’écran 2025-04-22 à 10 17 33](https://github.com/user-attachments/assets/8bf92a95-1df4-40df-bcf0-d31454c90080)

- [x] Mettre à jour le change log
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/37a331c647a38a191b2a1207?card=tra-16353)
