### PR TITLE
Hide tgap mention before 2024

### DIFF
--- a/src/maps/admin.py
+++ b/src/maps/admin.py
@@ -411,5 +411,8 @@ class DepartementsComputationAdmin(admin.ModelAdmin):
 
 @admin.register(InstallationsComputation)
 class InstallationsComputationAdmin(admin.ModelAdmin):
-    list_display = ["pk", "year", "created", "rubrique"]
+    list_display = ["pk", "siret", "year", "created", "rubrique"]
     list_filter = ["year"]
+    search_fields = [
+        "siret",
+    ]

--- a/src/maps/constants.py
+++ b/src/maps/constants.py
@@ -66,3 +66,5 @@ BSD_TYPES = [
     "dnd",
     "texs",
 ]
+
+MIN_TGAP_INFO_YEAR = 2024

--- a/src/maps/data/figures_factory.py
+++ b/src/maps/data/figures_factory.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 import plotly.graph_objects as go
 import polars as pl
 
-from maps.constants import ANNUAL_ICPE_RUBRIQUES
+from ..constants import ANNUAL_ICPE_RUBRIQUES, MIN_TGAP_INFO_YEAR
 
 gridcolor = "#ccc"
 
@@ -111,8 +111,8 @@ def create_icpe_graph(df: pl.DataFrame, key_column: str | None, rubrique: str) -
             font_size=13,
         )
         max_y = max(max_y, authorized_quantity)
-
-        if target_quantity is not None:
+        current_year = min(data["day_of_processing"]).year
+        if target_quantity is not None and current_year >= MIN_TGAP_INFO_YEAR:
             fig.add_hline(
                 y=target_quantity,
                 line_dash="dot",

--- a/src/sheets/graph_processors/plotly_components_processors.py
+++ b/src/sheets/graph_processors/plotly_components_processors.py
@@ -981,8 +981,8 @@ class ICPEAnnualItemProcessor:
                 line_dash="dot",
                 line_color="black",
                 line_width=2,
-                x=x.timestamp()
-                * 1000,  # Due to this bug : https://github.com/plotly/plotly.py/issues/3065, we have to convert to epoch here
+                x=x.timestamp() * 1000,
+                # Due to this bug : https://github.com/plotly/plotly.py/issues/3065, we have to convert to epoch here
                 annotation_text=f"{year}",
                 annotation_position="top right",
             )
@@ -1044,7 +1044,7 @@ class ICPEAnnualItemProcessor:
         fig.update_yaxes(
             range=[0, max_y * 1.3],
             gridcolor="#ccc",
-            title="Quantité traitée en tonnes<br>(somme cummulée annuellement)",
+            title="Quantité traitée en tonnes<br>(somme cumulée annuellement)",
         )
 
         fig.update_xaxes(


### PR DESCRIPTION
 Retour de https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16504
La règle d'affichage n'est applicable qu'aux graph de la carto des icpe, la fiche étab présentant un graphique pluriannuel.

Au passage fix de typo et ajout de filtres dans l'admin.

- [ ] Mettre à jour le change log
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16504)
