### PR TITLE
Use current domain in email context

### DIFF
--- a/src/accounts/templatetags/email_helpers.py
+++ b/src/accounts/templatetags/email_helpers.py
@@ -8,7 +8,9 @@ register = template.Library()
 
 @register.simple_tag(takes_context=True)
 def second_factor_url(context):
-    current_site = Site.objects.get_current()
+    current_site = context.get("current_site")
+    if not current_site:
+        current_site = Site.objects.first()
 
     domain = current_site.domain
     return f"https://{domain}{reverse_lazy('second_factor')}"
@@ -16,7 +18,7 @@ def second_factor_url(context):
 
 @register.simple_tag(takes_context=True)
 def logo_url(context):
-    current_site = Site.objects.get_current()
+    current_site = Site.objects.first()
 
     domain = current_site.domain
     return f"https://{domain}{static('img/trackdechets.png')}"

--- a/src/accounts/views.py
+++ b/src/accounts/views.py
@@ -4,6 +4,7 @@ from braces.views import LoginRequiredMixin
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.views import LoginView as BaseLoginView
+from django.contrib.sites.models import Site
 from django.http import HttpResponseRedirect, QueryDict
 from django.shortcuts import resolve_url
 from django.urls import reverse_lazy
@@ -31,11 +32,12 @@ class SendSecondFactorMailMixin:
     def process(self):
         user = self.request.user
         devices = EmailDevice.objects.devices_for_user(user)
+        current_site = Site.objects.get_current(self.request)
         if not devices:
             device = create_email_device(user)
         else:
             device = devices[0]
-        device.generate_challenge()
+        device.generate_challenge(extra_context={"current_site": current_site})
 
         if settings.DEBUG:
             # Print security code to console for quick reference, eliminating need to search through email output

--- a/src/config/settings/base.py
+++ b/src/config/settings/base.py
@@ -113,7 +113,6 @@ DWH_SSH_USERNAME = env.str("DWH_SSH_USERNAME")
 DWH_SSH_LOCAL_BIND_HOST = env.str("DWH_SSH_LOCAL_BIND_HOST")
 DWH_SSH_KEY = env.str("DWH_SSH_KEY", multiline=True)
 
-
 # Password validation
 # https://docs.djangoproject.com/en/4.1/ref/settings/#auth-password-validators
 AUTH_PASSWORD_VALIDATORS = [
@@ -180,8 +179,6 @@ CSV_FILES_DIR = SRC_DIR / "csv"
 MEDIA_ROOT = BASE_DIR / "public" / "medias"
 MEDIA_URL = "/medias/"
 
-SITE_ID = env.int("SITE_ID", 1)
-
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [
         "rest_framework.authentication.TokenAuthentication",
@@ -211,7 +208,6 @@ LOGOUT_REDIRECT_URL = "login"
 
 PASSWORD_RESET_TIMEOUT = 3600 * 12  # 12 hours
 
-
 GRAPPELLI_ADMIN_TITLE = "Vigiedéchets"
 GRAPPELLI_INDEX_DASHBOARD = "config.dashboard.CustomIndexDashboard"
 
@@ -229,10 +225,8 @@ if gdal_path := env.str("GDAL_LIBRARY_PATH", ""):
 if geos_path := env.str("GEOS_LIBRARY_PATH", ""):
     GEOS_LIBRARY_PATH = env.str("GEOS_LIBRARY_PATH")
 
-
 # Menu
 MENU_SELECT_PARENTS = True
-
 
 # moz oidc
 MONAIOT_OIDC_RP_CLIENT_ID = "trackdechets"
@@ -276,7 +270,6 @@ PROCONNECT_ALLOWED_IDP_IDS = [
     ID_ID_CURRASSO,
 ]
 
-
 OIDC_LOGIN_REDIRECT_URL = "private_home"
 
 # user
@@ -284,7 +277,6 @@ USE_X_FORWARDED_HOST = True
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
 CSRF_TRUSTED_ORIGINS = env.list("CSRF_TRUSTED_ORIGINS", default=[])
-
 
 # API
 TD_API_URL = env("TD_API_URL")

--- a/src/config/settings/dev.py
+++ b/src/config/settings/dev.py
@@ -27,8 +27,6 @@ CELERY_BROKER_URL = "redis://localhost:6379/0"
 CELERY_RESULT_BACKEND = "redis"
 
 OTP_EMAIL_TOKEN_VALIDITY = 600
-ALLOWED_HOSTS = ["dev.inspection.trackdechets.beta.gouv.fr", "127.0.0.1"]
-
 
 LOGGING = {
     "version": 1,


### PR DESCRIPTION
VD est actuellement déployé sous 2 domaines. Pour que les différents workflows impliquant des envois d'mails fonctionnent, le ndd concerné est injecté dans les emails le nécessitant.

La variable SITE_ID n'est plus requise.

- [ ] Mettre à jour le change log
---

- [Ticket Favro]()
