### PR TITLE
Ajoute un filtre manquant à la reqûete SQL `get_icpe_data`

### DIFF
--- a/src/sheets/queries.py
+++ b/src/sheets/queries.py
@@ -510,6 +510,7 @@ where siret = :siret
 and (
     libelle_etat_site not in ('A l’arrêt','Non construit','Projet abandonné','Sans titre')
     and etat_administratif_rubrique = 'En vigueur' 
+    and etat_technique_rubrique = 'Exploité'
     )
 """
 


### PR DESCRIPTION
Il faut aussi filtrer les rubriques pour ne prendre que celles en `etat_technique_rubrique = 'Exploité'`.

- [ ] Mettre à jour le change log
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/37a331c647a38a191b2a1207?card=tra-16810)
