### PR TITLE
chore(deps): bump celery from 5.5.3 to 5.6.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "MTE Vigiedéchets"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "celery==5.5.3",
+    "celery==5.6.2",
     "clickhouse-sqlalchemy>=0.2.3",
     "django>=5.2.8",
     "django-admin-rangefilter>=0.13.3",

--- a/uv.lock
+++ b/uv.lock
@@ -274,7 +274,7 @@ wheels = [
 
 [[package]]
 name = "celery"
-version = "5.5.3"
+version = "5.6.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "billiard" },
@@ -284,11 +284,12 @@ dependencies = [
     { name = "click-repl" },
     { name = "kombu" },
     { name = "python-dateutil" },
+    { name = "tzlocal" },
     { name = "vine" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/7d/6c289f407d219ba36d8b384b42489ebdd0c84ce9c413875a8aae0c85f35b/celery-5.5.3.tar.gz", hash = "sha256:6c972ae7968c2b5281227f01c3a3f984037d21c5129d07bf3550cc2afc6b10a5", size = 1667144, upload-time = "2025-06-01T11:08:12.563Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8f/9d/3d13596519cfa7207a6f9834f4b082554845eb3cd2684b5f8535d50c7c44/celery-5.6.2.tar.gz", hash = "sha256:4a8921c3fcf2ad76317d3b29020772103581ed2454c4c042cc55dcc43585009b", size = 1718802, upload-time = "2026-01-04T12:35:58.012Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/af/0dcccc7fdcdf170f9a1585e5e96b6fb0ba1749ef6be8c89a6202284759bd/celery-5.5.3-py3-none-any.whl", hash = "sha256:0b5761a07057acee94694464ca482416b959568904c9dfa41ce8413a7d65d525", size = 438775, upload-time = "2025-06-01T11:08:09.94Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/bd/9ecd619e456ae4ba73b6583cc313f26152afae13e9a82ac4fe7f8856bfd1/celery-5.6.2-py3-none-any.whl", hash = "sha256:3ffafacbe056951b629c7abcf9064c4a2366de0bdfc9fdba421b97ebb68619a5", size = 445502, upload-time = "2026-01-04T12:35:55.894Z" },
 ]
 
 [[package]]
@@ -1393,7 +1394,7 @@ wheels = [
 
 [[package]]
 name = "kombu"
-version = "5.5.4"
+version = "5.6.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "amqp" },
@@ -1401,9 +1402,9 @@ dependencies = [
     { name = "tzdata" },
     { name = "vine" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0f/d3/5ff936d8319ac86b9c409f1501b07c426e6ad41966fedace9ef1b966e23f/kombu-5.5.4.tar.gz", hash = "sha256:886600168275ebeada93b888e831352fe578168342f0d1d5833d88ba0d847363", size = 461992, upload-time = "2025-06-01T10:19:22.281Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/a5/607e533ed6c83ae1a696969b8e1c137dfebd5759a2e9682e26ff1b97740b/kombu-5.6.2.tar.gz", hash = "sha256:8060497058066c6f5aed7c26d7cd0d3b574990b09de842a8c5aaed0b92cc5a55", size = 472594, upload-time = "2025-12-29T20:30:07.779Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/70/a07dcf4f62598c8ad579df241af55ced65bed76e42e45d3c368a6d82dbc1/kombu-5.5.4-py3-none-any.whl", hash = "sha256:a12ed0557c238897d8e518f1d1fdf84bd1516c5e305af2dacd85c2015115feb8", size = 210034, upload-time = "2025-06-01T10:19:20.436Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/0f/834427d8c03ff1d7e867d3db3d176470c64871753252b21b4f4897d1fa45/kombu-5.6.2-py3-none-any.whl", hash = "sha256:efcfc559da324d41d61ca311b0c64965ea35b4c55cc04ee36e55386145dace93", size = 214219, upload-time = "2025-12-29T20:30:05.74Z" },
 ]
 
 [[package]]
@@ -2842,7 +2843,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "celery", specifier = "==5.5.3" },
+    { name = "celery", specifier = "==5.6.2" },
     { name = "clickhouse-sqlalchemy", specifier = ">=0.2.3" },
     { name = "django", specifier = ">=5.2.8" },
     { name = "django-admin-rangefilter", specifier = ">=0.13.3" },


### PR DESCRIPTION
## Mise à jour Celery 5.6.2 (et sa dépendance Kombu)
Cette PR valide le passage à `Celery 5.6.2`.

### Changements techniques
- `Celery & Kombu` : La montée de version de Celery entraîne automatiquement celle de `Kombu (5.4.x)`. Kombu étant la librairie gérant le transport des messages pour Celery, cette mise à jour assure une communication plus stable et résiliente avec notre broker Redis.

- `Synchronisation du Lock` : J'ai mis à jour le fichier uv.lock via `uv sync`. Ce choix est volontaire car la documentation du projet préconise une installation via `uv sync --frozen`, qui s'appuie strictement sur le lockfile.

### Note sur le pyproject.toml
- Le pyproject.toml actuel n'a pas été "upgradé" globalement (via `uv lock --upgrade`). Les plages de versions y sont encore trop larges, ce qui provoquerait des conflits entre d'autres dépendances (comme le duo `Paramiko/sshtunnel`).

- Il est donc recommandé de continuer à privilégier uv sync pour les mises à jour ciblées. Une révision plus stricte des versions dans le .toml pourra être envisagée ultérieurement pour sécuriser les futurs upgrades globaux.

[Pull Request du bot pour plus d'info sur la maj](https://github.com/MTES-MCT/trackdechets-vigiedechets/pull/415)