### PR TITLE
chore(deps-dev): bump globals from 15.15.0 to 17.4.0

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,7 +22,6 @@ export default tseslint.config(
       ecmaVersion: 2020,
       globals: {
         ...globals.browser,
-        ...globals.node,
       },
     },
     plugins: {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,24 +5,13 @@ import reactRefresh from "eslint-plugin-react-refresh";
 import tseslint from "typescript-eslint";
 
 export default tseslint.config(
-  { 
-    ignores: [
-    "dist",                  // Code compilé (illisible)
-    ".venv/**",              // Libs Python/Django (évite le crash RAM)
-    "node_modules/**",       // Libs JS externes
-    "**/static/admin/**",    // Code source admin Django
-    "**/static/grappelli/**" // Code source thème Grappelli
-  ]
-  },
-
+  { ignores: ["dist"] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ["src/static/ui_app_ts/src/**/*.{ts,tsx}"],
     languageOptions: {
       ecmaVersion: 2020,
-      globals: {
-        ...globals.browser,
-      },
+      globals: globals.browser,
     },
     plugins: {
       "react-hooks": reactHooks,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,13 +5,25 @@ import reactRefresh from "eslint-plugin-react-refresh";
 import tseslint from "typescript-eslint";
 
 export default tseslint.config(
-  { ignores: ["dist"] },
+  { 
+    ignores: [
+    "dist",                  // Code compilé (illisible)
+    ".venv/**",              // Libs Python/Django (évite le crash RAM)
+    "node_modules/**",       // Libs JS externes
+    "**/static/admin/**",    // Code source admin Django
+    "**/static/grappelli/**" // Code source thème Grappelli
+  ]
+  },
+
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ["src/static/ui_app_ts/src/**/*.{ts,tsx}"],
     languageOptions: {
       ecmaVersion: 2020,
-      globals: globals.browser,
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+      },
     },
     plugins: {
       "react-hooks": reactHooks,

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "eslint": "^9.21.0",
     "eslint-plugin-react-hooks": "^5.1.0",
     "eslint-plugin-react-refresh": "^0.4.19",
-    "globals": "^15.15.0",
+    "globals": "^17.0.0",
     "prettier": "^3.5.3",
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.24.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,8 +67,8 @@ importers:
         specifier: ^0.4.19
         version: 0.4.19(eslint@9.22.0)
       globals:
-        specifier: ^15.15.0
-        version: 15.15.0
+        specifier: ^17.0.0
+        version: 17.4.0
       prettier:
         specifier: ^3.5.3
         version: 3.5.3
@@ -933,8 +933,8 @@ packages:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
 
-  globals@15.15.0:
-    resolution: {integrity: sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==}
+  globals@17.4.0:
+    resolution: {integrity: sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==}
     engines: {node: '>=18'}
 
   gopd@1.2.0:
@@ -2170,7 +2170,7 @@ snapshots:
 
   globals@14.0.0: {}
 
-  globals@15.15.0: {}
+  globals@17.4.0: {}
 
   gopd@1.2.0: {}
 


### PR DESCRIPTION
# Mise à jour de globals 17.4.0

## Ce que j'ai modifié
- Mise à jour de globals : Passage de la version 15.15.0 à 17.4.0 dans le package.json.
- Mise à jour du pnpm-lock.yaml : Synchronisation du lockfile pour refléter les nouveaux changements.

## Support des standards modernes
La montée de version vers globals 17.4.0 (via ^17.0.0) permet de supporter les derniers environnements JavaScript et d'éviter des erreurs de définition sur les variables globales récentes (ES2024+).

## Conformité avec la documentation (pnpm)
J'ai mis à jour le fichier pnpm-lock.yaml pour garantir la compatibilité avec la procédure d'installation standard du projet :
$ pnpm install --frozen-lockfile --dev --ignore-scripts

L'utilisation du flag --frozen-lockfile impose d'avoir un lockfile parfaitement à jour avec le package.json, sinon l'installation échoue dans les environnements de CI/CD ou chez les autres développeurs.

## Validation
Validation finale via le script ./lint.sh : tous les tests passent avec succès.

[Pull request du bot pour plus d'info sur la maj](https://github.com/MTES-MCT/trackdechets-vigiedechets/pull/428)