### PR TITLE
Tra 17566/enable registry export by siren or siret

### DIFF
--- a/src/registry/admin.py
+++ b/src/registry/admin.py
@@ -40,6 +40,7 @@ class RegistryV2ExportAdmin(admin.ModelAdmin):
 
 class RegistryV2ExportSiretInline(admin.TabularInline):
     """Inline admin for viewing child SIRET exports"""
+
     model = RegistryV2ExportSiret
     extra = 0
     readonly_fields = ["id", "siret", "state", "registry_export_id", "created_at"]

--- a/src/registry/admin.py
+++ b/src/registry/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from .models import RegistryDownload, RegistryV2Export
+from .models import RegistryDownload, RegistryV2Export, RegistryV2ExportSiren, RegistryV2ExportSiret
 from .task import process_export
 
 
@@ -36,3 +36,60 @@ class RegistryV2ExportAdmin(admin.ModelAdmin):
     def action_update_export(self, request, queryset):
         for obj in queryset:
             process_export(obj.pk)
+
+
+class RegistryV2ExportSiretInline(admin.TabularInline):
+    """Inline admin for viewing child SIRET exports"""
+    model = RegistryV2ExportSiret
+    extra = 0
+    readonly_fields = ["id", "siret", "state", "registry_export_id", "created_at"]
+    fields = ["siret", "state", "registry_export_id", "created_at"]
+    can_delete = False
+    show_change_link = True
+
+
+@admin.register(RegistryV2ExportSiren)
+class RegistryV2ExportSirenAdmin(admin.ModelAdmin):
+    list_display = [
+        "id",
+        "siren",
+        "state",
+        "total_sirets",
+        "completed_sirets",
+        "failed_sirets",
+        "export_format",
+        "created_at",
+        "registry_type",
+        "start_date",
+        "end_date",
+        "created_by_email",
+    ]
+    list_filter = ["registry_type", "export_format", "state"]
+    search_fields = ["siren", "created_by_email"]
+    list_select_related = ["created_by"]
+    readonly_fields = ["total_sirets", "completed_sirets", "failed_sirets"]
+    inlines = [RegistryV2ExportSiretInline]
+    actions = [
+        "action_update_export",
+    ]
+
+    @admin.action(description="Refresh registry states by checking Trackdéchets api")
+    def action_update_export(self, request, queryset):
+        for obj in queryset:
+            process_export(obj.pk)
+
+
+@admin.register(RegistryV2ExportSiret)
+class RegistryV2ExportSiretAdmin(admin.ModelAdmin):
+    list_display = [
+        "id",
+        "siret",
+        "parent",
+        "state",
+        "registry_export_id",
+        "created_at",
+    ]
+    list_filter = ["state", "parent"]
+    search_fields = ["siret", "parent__siren"]
+    list_select_related = ["parent"]
+    readonly_fields = ["parent", "siret", "state", "registry_export_id", "created_at"]

--- a/src/registry/constants.py
+++ b/src/registry/constants.py
@@ -79,6 +79,13 @@ class RegistryV2DeclarationType(models.TextChoices):
     REGISTRY = "REGISTRY", "Déclaré (registre national)"
 
 
+class RegistryV2IdentifierType(models.TextChoices):
+    """Type of identifier used for export."""
+
+    SIRET = "SIRET", "SIRET (établissement)"
+    SIREN = "SIREN", "SIREN (entreprise - tous les établissements)"
+
+
 class RegistryV2WasteCode(models.TextChoices):
     WASTE_01_01_01 = "01 01 01", "01 01 01 - déchets provenant de l'extraction des minéraux métallifères"
     WASTE_01_01_02 = "01 01 02", "01 01 02 - déchets provenant de l'extraction des minéraux non métallifères"

--- a/src/registry/factories.py
+++ b/src/registry/factories.py
@@ -3,7 +3,7 @@ from factory.django import DjangoModelFactory
 
 from accounts.factories import UserFactory
 
-from .models import RegistryV2Export
+from .models import RegistryV2Export, RegistryV2ExportSiren, RegistryV2ExportSiret
 
 
 class RegistryV2ExportFactory(DjangoModelFactory):
@@ -14,3 +14,23 @@ class RegistryV2ExportFactory(DjangoModelFactory):
 
     siret = factory.Sequence(lambda n: str(n))
     created_by = factory.SubFactory(UserFactory)
+
+
+class RegistryV2ExportSirenFactory(DjangoModelFactory):
+    """Factory for the RegistryV2ExportSiren model."""
+
+    class Meta:
+        model = RegistryV2ExportSiren
+
+    siren = factory.Sequence(lambda n: str(n).zfill(9))
+    created_by = factory.SubFactory(UserFactory)
+
+
+class RegistryV2ExportSiretFactory(DjangoModelFactory):
+    """Factory for the RegistryV2ExportSiret model."""
+
+    class Meta:
+        model = RegistryV2ExportSiret
+
+    parent = factory.SubFactory(RegistryV2ExportSirenFactory)
+    siret = factory.Sequence(lambda n: str(n).zfill(14))

--- a/src/registry/forms.py
+++ b/src/registry/forms.py
@@ -8,13 +8,40 @@ from sqlalchemy.sql import text
 
 from sheets.datawarehouse import get_wh_sqlachemy_engine
 from sheets.forms import TypedDateInput
-from sheets.queries import sql_company_query_exists_str
+from sheets.queries import sql_company_query_exists_str, sql_get_linked_companies_data_from_siren
 from sheets.ssh import ssh_tunnel
 
-from .models import RegistryV2Export
+from .constants import RegistryV2IdentifierType
+from .models import RegistryV2Export, RegistryV2ExportSiren, RegistryV2ExportSiret
 
 
 class RegistryV2PrepareForm(forms.ModelForm):
+    """Form for creating registry exports - supports both SIRET and SIREN"""
+
+    identifier_type = forms.ChoiceField(
+        label="Type d'identifiant",
+        choices=[
+            (RegistryV2IdentifierType.SIRET, RegistryV2IdentifierType.SIRET.label),
+            (RegistryV2IdentifierType.SIREN, RegistryV2IdentifierType.SIREN.label),
+        ],
+        widget=forms.RadioSelect,
+        initial=RegistryV2IdentifierType.SIRET,
+    )
+
+    siret = forms.CharField(
+        label="SIRET",
+        max_length=14,
+        required=False,
+        help_text="14 chiffres du SIRET",
+    )
+
+    siren = forms.CharField(
+        label="SIREN",
+        max_length=9,
+        required=False,
+        help_text="9 chiffres du SIREN",
+    )
+
     start_date = forms.DateField(
         label="Date de début",
         widget=TypedDateInput,
@@ -47,8 +74,76 @@ class RegistryV2PrepareForm(forms.ModelForm):
             {"max": dt.date(day=31, month=12, year=dt.date.today().year).isoformat()}
         )
 
+        # Add JavaScript-friendly attributes for conditional display
+        self.fields["identifier_type"].widget.attrs.update(
+            {
+                "data-toggle": "identifier-type",
+            }
+        )
+        self.fields["siret"].widget.attrs.update(
+            {
+                "data-show-when": RegistryV2IdentifierType.SIRET,
+            }
+        )
+        self.fields["siren"].widget.attrs.update(
+            {
+                "data-show-when": RegistryV2IdentifierType.SIREN,
+            }
+        )
+
+    def clean_identifier_type(self):
+        identifier_type = self.cleaned_data.get("identifier_type")
+        if identifier_type not in [RegistryV2IdentifierType.SIRET, RegistryV2IdentifierType.SIREN]:
+            raise ValidationError("Type d'identifiant invalide")
+        return identifier_type
+
+    def clean_siret(self):
+        siret = self.cleaned_data.get("siret")
+        identifier_type = self.cleaned_data.get("identifier_type")
+
+        if identifier_type == RegistryV2IdentifierType.SIRET:
+            if not siret:
+                raise ValidationError("Le SIRET est requis")
+            if not siret.isdigit() or len(siret) != 14:
+                raise ValidationError("Le SIRET doit contenir exactement 14 chiffres")
+
+            # Validate SIRET exists in ClickHouse
+            if not getattr(settings, "SKIP_SIRET_CHECK", False):
+                if not self._siret_exists(siret):
+                    raise ValidationError("Établissement non inscrit sur Trackdéchets.")
+
+        return siret
+
+    def clean_siren(self):
+        siren = self.cleaned_data.get("siren")
+        identifier_type = self.cleaned_data.get("identifier_type")
+
+        if identifier_type == RegistryV2IdentifierType.SIREN:
+            if not siren:
+                raise ValidationError("Le SIREN est requis")
+            if not siren.isdigit() or len(siren) != 9:
+                raise ValidationError("Le SIREN doit contenir exactement 9 chiffres")
+
+            # Validate SIREN has at least one SIRET
+            if not getattr(settings, "SKIP_SIRET_CHECK", False):
+                sirets = self._get_sirets_for_siren(siren)
+                if not sirets:
+                    raise ValidationError("Aucun établissement trouvé pour ce SIREN sur Trackdéchets.")
+
+        return siren
+
     def clean(self):
         cleaned_data = super().clean()
+        identifier_type = cleaned_data.get("identifier_type")
+        siret = cleaned_data.get("siret")
+        siren = cleaned_data.get("siren")
+
+        # Ensure at least one identifier is provided based on type
+        if identifier_type == RegistryV2IdentifierType.SIRET and not siret:
+            raise ValidationError({"siret": "Le SIRET est requis"})
+        if identifier_type == RegistryV2IdentifierType.SIREN and not siren:
+            raise ValidationError({"siren": "Le SIREN est requis"})
+
         start_date = cleaned_data.get("start_date")
         end_date = cleaned_data.get("end_date")
         if end_date and start_date:
@@ -60,6 +155,8 @@ class RegistryV2PrepareForm(forms.ModelForm):
         waste_types_texs = cleaned_data.get("waste_types_texs")
         if not any([waste_types_dnd, waste_types_dd, waste_types_texs]):
             raise ValidationError("Sélectionner au moins un type de déchets")
+
+        return cleaned_data
 
     def clean_start_date(self):
         start_date = self.cleaned_data["start_date"]
@@ -81,32 +178,79 @@ class RegistryV2PrepareForm(forms.ModelForm):
                 raise ValidationError("Les dates postérieures à aujourd'hui ne sont pas acceptées pour le registre")
         return end_date
 
-    def clean_siret(self):
-        siret = self.cleaned_data["siret"]
-        if getattr(settings, "SKIP_SIRET_CHECK", False):
-            return siret
+    def _siret_exists(self, siret):
+        """Check if SIRET exists in ClickHouse"""
         prepared_query = text(sql_company_query_exists_str)
 
         with ssh_tunnel(settings):
             wh_engine = get_wh_sqlachemy_engine()
             with wh_engine.connect() as con:
                 companies = con.execute(prepared_query, {"siret": siret}).all()
-            if not companies:
-                raise ValidationError("Établissement non inscrit sur Trackdéchets.")
-            return siret
+            return bool(companies)
+
+    def _get_sirets_for_siren(self, siren):
+        """Get all SIRETs for a SIREN from ClickHouse"""
+        prepared_query = text(sql_get_linked_companies_data_from_siren)
+
+        with ssh_tunnel(settings):
+            wh_engine = get_wh_sqlachemy_engine()
+            with wh_engine.connect() as con:
+                # Use any SIRET starting with this SIREN as parameter
+                # (the query uses substring comparison)
+                results = con.execute(prepared_query, {"siren": siren}).all()
+                return [row[0] for row in results]  # Extract SIRETs
 
     def save(self, commit=True):
-        export = super().save(commit=False)
-        export.created_by = self.created_by
-        export.created_by_email = self.created_by.email
-        if commit:
-            export.save()
-        return export
+        identifier_type = self.cleaned_data.get("identifier_type")
+
+        if identifier_type == RegistryV2IdentifierType.SIREN:
+            # Create SIREN-based export
+            siren = self.cleaned_data.get("siren")
+            siren_export = RegistryV2ExportSiren(
+                siren=siren,
+                registry_type=self.cleaned_data.get("registry_type"),
+                declaration_type=self.cleaned_data.get("declaration_type"),
+                waste_types_dnd=self.cleaned_data.get("waste_types_dnd"),
+                waste_types_dd=self.cleaned_data.get("waste_types_dd"),
+                waste_types_texs=self.cleaned_data.get("waste_types_texs"),
+                waste_codes=self.cleaned_data.get("waste_codes", []),
+                start_date=self.cleaned_data.get("start_date"),
+                end_date=self.cleaned_data.get("end_date"),
+                export_format=self.cleaned_data.get("export_format"),
+                created_by=self.created_by,
+                created_by_email=self.created_by.email,
+            )
+
+            if commit:
+                siren_export.save()
+                # Create child exports for each SIRET
+                sirets = self._get_sirets_for_siren(siren)
+                siren_export.total_sirets = len(sirets)
+                siren_export.save()
+
+                for siret in sirets:
+                    RegistryV2ExportSiret.objects.create(
+                        parent=siren_export,
+                        siret=siret,
+                    )
+
+            return siren_export
+        else:
+            # Create SIRET-based export (existing logic)
+            export = super().save(commit=False)
+            export.siret = self.cleaned_data.get("siret")
+            export.created_by = self.created_by
+            export.created_by_email = self.created_by.email
+            if commit:
+                export.save()
+            return export
 
     class Meta:
-        model = RegistryV2Export
+        model = RegistryV2Export  # Base model for form
         fields = [
-            "siret",
+            "identifier_type",  # NEW
+            "siret",  # Conditional
+            "siren",  # NEW, conditional
             "registry_type",
             "declaration_type",
             "waste_types_dnd",

--- a/src/registry/forms.py
+++ b/src/registry/forms.py
@@ -129,6 +129,7 @@ class RegistryV2PrepareForm(forms.ModelForm):
                 sirets = self._get_sirets_for_siren(siren)
                 if not sirets:
                     raise ValidationError("Aucun établissement trouvé pour ce SIREN sur Trackdéchets.")
+                self._cached_sirets = sirets
 
         return siren
 
@@ -214,8 +215,8 @@ class RegistryV2PrepareForm(forms.ModelForm):
 
             if commit:
                 siren_export.save()
-                # Create child exports for each SIRET
-                sirets = self._get_sirets_for_siren(siren)
+                # Create child exports for each SIRET (reuse cached result from clean_siren)
+                sirets = getattr(self, "_cached_sirets", None) or self._get_sirets_for_siren(siren)
                 siren_export.total_sirets = len(sirets)
                 siren_export.save()
 

--- a/src/registry/forms.py
+++ b/src/registry/forms.py
@@ -134,15 +134,6 @@ class RegistryV2PrepareForm(forms.ModelForm):
 
     def clean(self):
         cleaned_data = super().clean()
-        identifier_type = cleaned_data.get("identifier_type")
-        siret = cleaned_data.get("siret")
-        siren = cleaned_data.get("siren")
-
-        # Ensure at least one identifier is provided based on type
-        if identifier_type == RegistryV2IdentifierType.SIRET and not siret:
-            raise ValidationError({"siret": "Le SIRET est requis"})
-        if identifier_type == RegistryV2IdentifierType.SIREN and not siren:
-            raise ValidationError({"siren": "Le SIREN est requis"})
 
         start_date = cleaned_data.get("start_date")
         end_date = cleaned_data.get("end_date")
@@ -228,11 +219,15 @@ class RegistryV2PrepareForm(forms.ModelForm):
                 siren_export.total_sirets = len(sirets)
                 siren_export.save()
 
+                siret_exports = []
                 for siret in sirets:
-                    RegistryV2ExportSiret.objects.create(
-                        parent=siren_export,
-                        siret=siret,
+                    siret_exports.append(
+                        RegistryV2ExportSiret(
+                            parent=siren_export,
+                            siret=siret,
+                        )
                     )
+                RegistryV2ExportSiret.objects.bulk_create(siret_exports)
 
             return siren_export
         else:

--- a/src/registry/migrations/0006_registryv2exportsiren_registryv2exportsiret.py
+++ b/src/registry/migrations/0006_registryv2exportsiren_registryv2exportsiret.py
@@ -1,0 +1,83 @@
+# Generated manually
+
+import datetime
+import uuid
+
+import django.db.models.deletion
+import django.utils.timezone
+from django.conf import settings
+from django.db import migrations, models
+
+import registry.models
+from registry.constants import RegistryV2WasteCode
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('registry', '0005_alter_registryv2export_registry_type'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='RegistryV2ExportSiren',
+            fields=[
+                ('id', models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True, serialize=False)),
+                ('siren', models.CharField(db_index=True, max_length=9, verbose_name='SIREN')),
+                ('registry_type', models.CharField(choices=[('INCOMING', 'Registre entrant'), ('MANAGED', 'Registre des courtiers/négociants'), ('OUTGOING', 'Registre sortant'), ('SSD', 'Registre Sortie de statut de déchet'), ('TRANSPORTED', 'Registre des transporteurs')], default='INCOMING', max_length=20, verbose_name='Type de registre')),
+                ('declaration_type', models.CharField(choices=[('ALL', 'Tous'), ('BSD', 'Tracé (bordereaux)'), ('REGISTRY', 'Déclaré (registre national)')], default='ALL', max_length=20, verbose_name='Type de déclaration')),
+                ('waste_types_dnd', models.BooleanField(blank=True, default=False, verbose_name='Déchets non dangereux')),
+                ('waste_types_dd', models.BooleanField(blank=True, default=False, verbose_name='Déchets dangereux')),
+                ('waste_types_texs', models.BooleanField(blank=True, default=False, verbose_name='Terres et sédiments')),
+                ('waste_codes', registry.models.ChoiceArrayField(base_field=models.CharField(blank=True, choices=RegistryV2WasteCode.choices, max_length=32), blank=True, default=list, size=None, verbose_name='Codes déchets')),
+                ('start_date', models.DateTimeField(default=datetime.datetime(2022, 1, 1, 0, 0), verbose_name='Data Start Date')),
+                ('end_date', models.DateTimeField(default=django.utils.timezone.now, verbose_name='End Date')),
+                ('export_format', models.CharField(choices=[('CSV', 'Texte (.csv)'), ('XLSX', 'Excel (.xlsx)')], default='CSV', max_length=20, verbose_name="Format d'export")),
+                ('state', models.CharField(choices=[('PENDING', 'En attente'), ('STARTED', 'En cours'), ('SUCCESSFUL', 'Terminé'), ('FAILED', 'Erreur'), ('CANCELED', 'Annulé')], default='PENDING', max_length=20, verbose_name='State')),
+                ('total_sirets', models.IntegerField(default=0, verbose_name='Total SIRETs')),
+                ('completed_sirets', models.IntegerField(default=0, verbose_name='Completed SIRETs')),
+                ('failed_sirets', models.IntegerField(default=0, verbose_name='Failed SIRETs')),
+                ('created_at', models.DateTimeField(default=django.utils.timezone.now, verbose_name='Created')),
+                ('created_by_email', models.EmailField(blank=True, max_length=254, verbose_name='Created by email')),
+                ('created_by', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to=settings.AUTH_USER_MODEL, verbose_name='Created by')),
+            ],
+            options={
+                'verbose_name': 'Téléchargement de registre V2 (SIREN)',
+                'verbose_name_plural': 'Téléchargements de registre V2 (SIREN)',
+                'ordering': ('-created_at',),
+            },
+        ),
+        migrations.CreateModel(
+            name='RegistryV2ExportSiret',
+            fields=[
+                ('id', models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True, serialize=False)),
+                ('siret', models.CharField(db_index=True, max_length=14, verbose_name='SIRET')),
+                ('state', models.CharField(choices=[('PENDING', 'En attente'), ('STARTED', 'En cours'), ('SUCCESSFUL', 'Terminé'), ('FAILED', 'Erreur'), ('CANCELED', 'Annulé')], default='PENDING', max_length=20, verbose_name='State')),
+                ('registry_export_id', models.CharField(blank=True, verbose_name='Trackdéchets Export id')),
+                ('created_at', models.DateTimeField(default=django.utils.timezone.now, verbose_name='Created')),
+                ('parent', models.ForeignKey(db_index=True, on_delete=django.db.models.deletion.CASCADE, related_name='siret_exports', to='registry.registryv2exportsiren', verbose_name='Parent')),
+            ],
+            options={
+                'verbose_name': 'Export SIRET (enfant)',
+                'verbose_name_plural': 'Exports SIRET (enfants)',
+                'ordering': ('siret',),
+            },
+        ),
+        migrations.AddIndex(
+            model_name='registryv2exportsiren',
+            index=models.Index(fields=['siren'], name='registry_re_siren_abc123_idx'),
+        ),
+        migrations.AddIndex(
+            model_name='registryv2exportsiren',
+            index=models.Index(fields=['state'], name='registry_re_state_def456_idx'),
+        ),
+        migrations.AddIndex(
+            model_name='registryv2exportsiret',
+            index=models.Index(fields=['parent', 'state'], name='registry_re_parent__ghi789_idx'),
+        ),
+        migrations.AddIndex(
+            model_name='registryv2exportsiret',
+            index=models.Index(fields=['siret'], name='registry_re_siret_jkl012_idx'),
+        ),
+    ]

--- a/src/registry/models.py
+++ b/src/registry/models.py
@@ -178,3 +178,207 @@ class RegistryV2Export(models.Model):
         if where:
             variables.update({"where": where})
         return variables
+
+
+class RegistryV2ExportSiren(models.Model):
+    """Parent export model for SIREN-based exports"""
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    siren = models.CharField(_("SIREN"), max_length=9, db_index=True)
+    registry_type = models.CharField(
+        _("Type de registre"),
+        max_length=20,
+        choices=RegistryV2ExportType.choices,
+        default=RegistryV2ExportType.INCOMING,
+    )
+    declaration_type = models.CharField(
+        _("Type de déclaration"),
+        max_length=20,
+        choices=RegistryV2DeclarationType.choices,
+        default=RegistryV2DeclarationType.ALL,
+    )
+    waste_types_dnd = models.BooleanField(_("Déchets non dangereux"), default=False, blank=True)
+    waste_types_dd = models.BooleanField(_("Déchets dangereux"), default=False, blank=True)
+    waste_types_texs = models.BooleanField(_("Terres et sédiments"), default=False, blank=True)
+
+    waste_codes = ChoiceArrayField(
+        models.CharField(max_length=32, blank=True, choices=RegistryV2WasteCode),
+        verbose_name=_("Codes déchets"),
+        default=list,
+        blank=True,
+    )
+    start_date = models.DateTimeField(_("Data Start Date"), default=datetime(2022, 1, 1))
+    end_date = models.DateTimeField(_("End Date"), default=timezone.now)
+    export_format = models.CharField(
+        _("Format d'export"),
+        max_length=20,
+        choices=RegistryV2Format.choices,
+        default=RegistryV2Format.CSV,
+    )
+
+    state = models.CharField(
+        _("State"),
+        max_length=20,
+        choices=RegistryV2ExportState.choices,
+        default=RegistryV2ExportState.PENDING,
+    )
+
+    total_sirets = models.IntegerField(_("Total SIRETs"), default=0)
+    completed_sirets = models.IntegerField(_("Completed SIRETs"), default=0)
+    failed_sirets = models.IntegerField(_("Failed SIRETs"), default=0)
+
+    created_at = models.DateTimeField(_("Created"), default=timezone.now)
+    created_by = models.ForeignKey(
+        User, verbose_name=_("Created by"), on_delete=models.SET_NULL, blank=True, null=True
+    )
+    created_by_email = models.EmailField(
+        verbose_name=_("Created by email"), blank=True
+    )  # keep history if user is deleted
+
+    objects = RegistryV2ExportQuerySet.as_manager()
+
+    class Meta:
+        verbose_name = _("Téléchargement de registre V2 (SIREN)")
+        verbose_name_plural = _("Téléchargements de registre V2 (SIREN)")
+        ordering = ("-created_at",)
+        indexes = [
+            models.Index(fields=["siren"]),
+            models.Index(fields=["state"]),
+        ]
+
+    def __str__(self):
+        return f"Export SIREN {self.siren} ({self.completed_sirets}/{self.total_sirets})"
+
+    @property
+    def successful(self):
+        return self.state == RegistryV2ExportState.SUCCESSFUL
+
+    @property
+    def is_timeout(self):
+        return timezone.now() - self.created_at > dt.timedelta(minutes=MAX_PROCESSING_DELAY)
+
+    @property
+    def in_progress(self):
+        return self.state in [RegistryV2ExportState.PENDING, RegistryV2ExportState.STARTED] and not self.is_timeout
+
+    @property
+    def waste_types(self):
+        WASTE_TYPES = ["DND", "DD", "TEXS"]
+        bool_vector = [self.waste_types_dnd, self.waste_types_dd, self.waste_types_texs]
+
+        return [item for item, keep in zip(WASTE_TYPES, bool_vector) if keep]
+
+    @property
+    def all_sirets_completed(self):
+        return self.completed_sirets == self.total_sirets and self.total_sirets > 0
+
+    def update_aggregated_state(self):
+        """Recalculate state based on child exports"""
+        children = self.siret_exports.all()
+        if not children.exists():
+            return
+
+        completed = children.filter(state=RegistryV2ExportState.SUCCESSFUL).count()
+        failed = children.filter(state=RegistryV2ExportState.FAILED).count()
+        in_progress = children.filter(
+            state__in=[RegistryV2ExportState.PENDING, RegistryV2ExportState.STARTED]
+        ).exists()
+
+        self.completed_sirets = completed
+        self.failed_sirets = failed
+        self.total_sirets = children.count()
+
+        if completed == self.total_sirets:
+            self.state = RegistryV2ExportState.SUCCESSFUL
+        elif failed == self.total_sirets:
+            self.state = RegistryV2ExportState.FAILED
+        elif in_progress:
+            self.state = RegistryV2ExportState.STARTED
+        elif completed > 0:
+            # Partial success - keep as STARTED or add PARTIAL_SUCCESS state
+            self.state = RegistryV2ExportState.STARTED
+
+        self.save()
+
+
+class RegistryV2ExportSiret(models.Model):
+    """Child export model for individual SIRET within a SIREN export"""
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    parent = models.ForeignKey(
+        RegistryV2ExportSiren,
+        related_name="siret_exports",
+        on_delete=models.CASCADE,
+        db_index=True,
+    )
+    siret = models.CharField(_("SIRET"), max_length=14, db_index=True)
+
+    state = models.CharField(
+        _("State"),
+        max_length=20,
+        choices=RegistryV2ExportState.choices,
+        default=RegistryV2ExportState.PENDING,
+    )
+    registry_export_id = models.CharField(_("Trackdéchets Export id"), blank=True)
+
+    created_at = models.DateTimeField(_("Created"), default=timezone.now)
+
+    class Meta:
+        verbose_name = _("Export SIRET (enfant)")
+        verbose_name_plural = _("Exports SIRET (enfants)")
+        ordering = ("siret",)
+        indexes = [
+            models.Index(fields=["parent", "state"]),
+            models.Index(fields=["siret"]),
+        ]
+
+    def __str__(self):
+        return f"{self.siret} (parent: {self.parent.siren})"
+
+    @property
+    def successful(self):
+        return self.state == RegistryV2ExportState.SUCCESSFUL
+
+    @property
+    def is_timeout(self):
+        return timezone.now() - self.created_at > dt.timedelta(minutes=MAX_PROCESSING_DELAY)
+
+    @property
+    def in_progress(self):
+        return self.state in [RegistryV2ExportState.PENDING, RegistryV2ExportState.STARTED] and not self.is_timeout
+
+    def mark_as_failed(self):
+        self.state = RegistryV2ExportState.FAILED
+        self.save()
+
+    def get_gql_variables(self):
+        """Build GraphQL variables using parent's parameters and this SIRET"""
+        parent = self.parent
+        variables = {
+            "siret": self.siret,
+            "registryType": parent.registry_type,
+            "format": parent.export_format,
+            "dateRange": {
+                "_gte": parent.start_date.isoformat(),
+                "_lte": parent.end_date.isoformat(),
+            },
+        }
+        where = {"declarationType": {"_eq": parent.declaration_type}}
+
+        waste_types = []
+        if parent.waste_types_dnd:
+            waste_types.append("DND")
+        if parent.waste_types_dd:
+            waste_types.append("DD")
+        if parent.waste_types_texs:
+            waste_types.append("TEXS")
+
+        if waste_types:
+            where.update({"wasteType": {"_in": waste_types}})
+        if parent.waste_codes:
+            where.update({"wasteCode": {"_in": parent.waste_codes}})
+
+        if where:
+            variables.update({"where": where})
+        return variables

--- a/src/registry/models.py
+++ b/src/registry/models.py
@@ -280,7 +280,7 @@ class RegistryV2ExportSiren(models.Model):
             # Refresh self with select_for_update to get a locked instance
             locked_self = RegistryV2ExportSiren.objects.select_for_update().get(pk=self.pk)
             children = locked_self.siret_exports.select_for_update().all()
-            
+
             if not children.exists():
                 return
 

--- a/src/registry/models.py
+++ b/src/registry/models.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 from django import forms
 from django.contrib.postgres.fields import ArrayField
-from django.db import models
+from django.db import models, transaction
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
@@ -275,31 +275,38 @@ class RegistryV2ExportSiren(models.Model):
 
     def update_aggregated_state(self):
         """Recalculate state based on child exports"""
-        children = self.siret_exports.all()
-        if not children.exists():
-            return
+        with transaction.atomic():
+            # Lock parent and children to prevent concurrent updates
+            # Refresh self with select_for_update to get a locked instance
+            locked_self = RegistryV2ExportSiren.objects.select_for_update().get(pk=self.pk)
+            children = locked_self.siret_exports.select_for_update().all()
+            
+            if not children.exists():
+                return
 
-        completed = children.filter(state=RegistryV2ExportState.SUCCESSFUL).count()
-        failed = children.filter(state=RegistryV2ExportState.FAILED).count()
-        in_progress = children.filter(
-            state__in=[RegistryV2ExportState.PENDING, RegistryV2ExportState.STARTED]
-        ).exists()
+            completed = children.filter(state=RegistryV2ExportState.SUCCESSFUL).count()
+            failed = children.filter(state=RegistryV2ExportState.FAILED).count()
+            in_progress = children.filter(
+                state__in=[RegistryV2ExportState.PENDING, RegistryV2ExportState.STARTED]
+            ).exists()
 
-        self.completed_sirets = completed
-        self.failed_sirets = failed
-        self.total_sirets = children.count()
+            locked_self.completed_sirets = completed
+            locked_self.failed_sirets = failed
+            locked_self.total_sirets = children.count()
 
-        if completed == self.total_sirets:
-            self.state = RegistryV2ExportState.SUCCESSFUL
-        elif failed == self.total_sirets:
-            self.state = RegistryV2ExportState.FAILED
-        elif in_progress:
-            self.state = RegistryV2ExportState.STARTED
-        elif completed > 0:
-            # Partial success - keep as STARTED or add PARTIAL_SUCCESS state
-            self.state = RegistryV2ExportState.STARTED
+            if completed == locked_self.total_sirets:
+                locked_self.state = RegistryV2ExportState.SUCCESSFUL
+            elif failed == locked_self.total_sirets:
+                locked_self.state = RegistryV2ExportState.FAILED
+            elif in_progress:
+                locked_self.state = RegistryV2ExportState.STARTED
+            elif completed > 0:
+                # Partial success - keep as STARTED or add PARTIAL_SUCCESS state
+                locked_self.state = RegistryV2ExportState.STARTED
 
-        self.save()
+            locked_self.save()
+            # Refresh self to reflect changes
+            self.refresh_from_db()
 
 
 class RegistryV2ExportSiret(models.Model):

--- a/src/registry/task.py
+++ b/src/registry/task.py
@@ -98,7 +98,6 @@ def generate_registry_export(self, registry_v2_export_pk):
             headers={"Authorization": f"Bearer {settings.TD_API_TOKEN}"},
             json={
                 "query": graphql_generate_registry_export,
-                "query": graphql_generate_registry_export,
                 "variables": variables,
             },
         )

--- a/src/registry/task.py
+++ b/src/registry/task.py
@@ -44,7 +44,7 @@ def process_export(registry_v2_export_pk):
                 task_chain = chain(
                     generate_registry_export.s(siret_export.pk),
                     refresh_registry_export.s(siret_export.pk),
-                    update_siren_export_state.s(registry_v2_export_pk)
+                    update_siren_export_state.s(registry_v2_export_pk),
                 )
                 task_chain()
         return
@@ -60,8 +60,8 @@ MAX__GENERATE_DELAY = dt.timedelta(minutes=15)
 def generate_registry_export(self, registry_v2_export_pk):
     """Create a registry export on TD api"""
     geo_retry_delay = min(10 * self.request.retries, 300)
-    max_retries = getattr(self, 'max_retries', 3)  # Default to 3 if not set
-    
+    max_retries = getattr(self, "max_retries", 3)  # Default to 3 if not set
+
     try:
         export = RegistryV2ExportSiret.objects.get(pk=registry_v2_export_pk)
     except RegistryV2ExportSiret.DoesNotExist:
@@ -227,6 +227,7 @@ def refresh_registry_export(self, registry_v2_export_pk):
         logger.info("Api error")
         raise self.retry(countdown=geo_retry_delay)
 
+
 @app.task
 def update_siren_export_state(registry_v2_export_siren_pk):
     """Update parent SIREN export state based on children"""
@@ -235,7 +236,4 @@ def update_siren_export_state(registry_v2_export_siren_pk):
 
     # If not all completed, schedule another check
     if siren_export.state in [RegistryV2ExportState.PENDING, RegistryV2ExportState.STARTED]:
-        update_siren_export_state.apply_async(
-            args=[registry_v2_export_siren_pk],
-            countdown=10
-        )
+        update_siren_export_state.apply_async(args=[registry_v2_export_siren_pk], countdown=10)

--- a/src/registry/task.py
+++ b/src/registry/task.py
@@ -11,16 +11,28 @@ from config.celery_app import app
 
 from .constants import RegistryV2ExportState
 from .gql import graphql_generate_registry_export, graphql_read_registry_export
-from .models import RegistryV2ExportSiren, RegistryV2ExportSiret
+from .models import RegistryV2Export, RegistryV2ExportSiren, RegistryV2ExportSiret
 
 logger = logging.getLogger(__name__)
+
+
+def get_siret_export(registry_v2_export_pk):
+    try:
+        return RegistryV2ExportSiret.objects.get(pk=registry_v2_export_pk)
+    except RegistryV2ExportSiret.DoesNotExist:
+        try:
+            return RegistryV2Export.objects.get(pk=registry_v2_export_pk)
+        except RegistryV2Export.DoesNotExist:
+            return None
+    except RegistryV2ExportSiren.DoesNotExist:
+        return None
 
 
 def process_export(registry_v2_export_pk):
     """Process export - handles both SIRET and SIREN exports"""
     # Try to get as SIRET export first (backward compatibility)
     try:
-        RegistryV2ExportSiret.objects.get(pk=registry_v2_export_pk)
+        RegistryV2Export.objects.get(pk=registry_v2_export_pk)
         # Existing SIRET export logic
         if getattr(settings, "CELERY_TASK_ALWAYS_EAGER", False):
             generate_registry_export.delay(registry_v2_export_pk)
@@ -29,7 +41,7 @@ def process_export(registry_v2_export_pk):
         task_chain = chain(generate_registry_export.s(registry_v2_export_pk), refresh_registry_export.s())
         task_chain()
         return
-    except RegistryV2ExportSiret.DoesNotExist:
+    except RegistryV2Export.DoesNotExist:
         pass
 
     # Try as SIREN export
@@ -43,8 +55,8 @@ def process_export(registry_v2_export_pk):
             else:
                 task_chain = chain(
                     generate_registry_export.s(siret_export.pk),
-                    refresh_registry_export.s(siret_export.pk),
-                    update_siren_export_state.s(registry_v2_export_pk),
+                    refresh_registry_export.s(),
+                    update_siren_export_state.si(registry_v2_export_pk),
                 )
                 task_chain()
         return
@@ -62,9 +74,8 @@ def generate_registry_export(self, registry_v2_export_pk):
     geo_retry_delay = min(10 * self.request.retries, 300)
     max_retries = getattr(self, "max_retries", 3)  # Default to 3 if not set
 
-    try:
-        export = RegistryV2ExportSiret.objects.get(pk=registry_v2_export_pk)
-    except RegistryV2ExportSiret.DoesNotExist:
+    export = get_siret_export(registry_v2_export_pk)
+    if not export:
         logger.error(f"Export {registry_v2_export_pk} not found")
         return None
 
@@ -165,9 +176,8 @@ def refresh_registry_export(self, registry_v2_export_pk):
     static_retry_delay = 10
     geo_retry_delay = min(10 * self.request.retries, 300)
 
-    try:
-        export = RegistryV2ExportSiret.objects.get(pk=registry_v2_export_pk)
-    except RegistryV2ExportSiret.DoesNotExist:
+    export = get_siret_export(registry_v2_export_pk)
+    if not export:
         if self.request.retries < 3:
             # retry 2 times with a 1s delay
             raise self.retry(countdown=1)
@@ -176,7 +186,6 @@ def refresh_registry_export(self, registry_v2_export_pk):
 
     if export.state in [
         RegistryV2ExportState.CANCELED,
-        RegistryV2ExportState.SUCCESSFUL,
         RegistryV2ExportState.SUCCESSFUL,
     ]:
         return None

--- a/src/registry/task.py
+++ b/src/registry/task.py
@@ -24,8 +24,6 @@ def get_siret_export(registry_v2_export_pk):
             return RegistryV2Export.objects.get(pk=registry_v2_export_pk)
         except RegistryV2Export.DoesNotExist:
             return None
-    except RegistryV2ExportSiren.DoesNotExist:
-        return None
 
 
 def process_export(registry_v2_export_pk):
@@ -59,6 +57,9 @@ def process_export(registry_v2_export_pk):
                     update_siren_export_state.si(registry_v2_export_pk),
                 )
                 task_chain()
+
+        if getattr(settings, "CELERY_TASK_ALWAYS_EAGER", False):
+            update_siren_export_state.delay(registry_v2_export_pk)
         return
     except RegistryV2ExportSiren.DoesNotExist:
         logger.error(f"Export {registry_v2_export_pk} not found")

--- a/src/registry/task.py
+++ b/src/registry/task.py
@@ -11,7 +11,7 @@ from config.celery_app import app
 
 from .constants import RegistryV2ExportState
 from .gql import graphql_generate_registry_export, graphql_read_registry_export
-from .models import RegistryV2Export, RegistryV2ExportSiren, RegistryV2ExportSiret
+from .models import RegistryV2ExportSiren, RegistryV2ExportSiret
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +20,7 @@ def process_export(registry_v2_export_pk):
     """Process export - handles both SIRET and SIREN exports"""
     # Try to get as SIRET export first (backward compatibility)
     try:
-        RegistryV2Export.objects.get(pk=registry_v2_export_pk)
+        RegistryV2ExportSiret.objects.get(pk=registry_v2_export_pk)
         # Existing SIRET export logic
         if getattr(settings, "CELERY_TASK_ALWAYS_EAGER", False):
             generate_registry_export.delay(registry_v2_export_pk)
@@ -29,13 +29,24 @@ def process_export(registry_v2_export_pk):
         task_chain = chain(generate_registry_export.s(registry_v2_export_pk), refresh_registry_export.s())
         task_chain()
         return
-    except RegistryV2Export.DoesNotExist:
+    except RegistryV2ExportSiret.DoesNotExist:
         pass
 
     # Try as SIREN export
     try:
-        RegistryV2ExportSiren.objects.get(pk=registry_v2_export_pk)
-        process_siren_export(registry_v2_export_pk)
+        siren_export = RegistryV2ExportSiren.objects.get(pk=registry_v2_export_pk)
+        siret_exports = siren_export.siret_exports.all()
+
+        for siret_export in siret_exports:
+            if getattr(settings, "CELERY_TASK_ALWAYS_EAGER", False):
+                generate_registry_export.delay(siret_export.pk)
+            else:
+                task_chain = chain(
+                    generate_registry_export.s(siret_export.pk),
+                    refresh_registry_export.s(siret_export.pk),
+                    update_siren_export_state.s(registry_v2_export_pk)
+                )
+                task_chain()
         return
     except RegistryV2ExportSiren.DoesNotExist:
         logger.error(f"Export {registry_v2_export_pk} not found")
@@ -52,8 +63,8 @@ def generate_registry_export(self, registry_v2_export_pk):
     max_retries = getattr(self, 'max_retries', 3)  # Default to 3 if not set
     
     try:
-        export = RegistryV2Export.objects.get(pk=registry_v2_export_pk)
-    except RegistryV2Export.DoesNotExist:
+        export = RegistryV2ExportSiret.objects.get(pk=registry_v2_export_pk)
+    except RegistryV2ExportSiret.DoesNotExist:
         logger.error(f"Export {registry_v2_export_pk} not found")
         return None
 
@@ -75,6 +86,7 @@ def generate_registry_export(self, registry_v2_export_pk):
             url=settings.TD_API_URL,
             headers={"Authorization": f"Bearer {settings.TD_API_TOKEN}"},
             json={
+                "query": graphql_generate_registry_export,
                 "query": graphql_generate_registry_export,
                 "variables": variables,
             },
@@ -154,8 +166,8 @@ def refresh_registry_export(self, registry_v2_export_pk):
     geo_retry_delay = min(10 * self.request.retries, 300)
 
     try:
-        export = RegistryV2Export.objects.get(pk=registry_v2_export_pk)
-    except RegistryV2Export.DoesNotExist:
+        export = RegistryV2ExportSiret.objects.get(pk=registry_v2_export_pk)
+    except RegistryV2ExportSiret.DoesNotExist:
         if self.request.retries < 3:
             # retry 2 times with a 1s delay
             raise self.retry(countdown=1)
@@ -214,192 +226,6 @@ def refresh_registry_export(self, registry_v2_export_pk):
         # Api error, geometric retry delay
         logger.info("Api error")
         raise self.retry(countdown=geo_retry_delay)
-
-
-def process_siren_export(registry_v2_export_siren_pk):
-    """Process SIREN export by creating tasks for each SIRET"""
-    siren_export = RegistryV2ExportSiren.objects.get(pk=registry_v2_export_siren_pk)
-    siret_exports = siren_export.siret_exports.all()
-
-    for siret_export in siret_exports:
-        if getattr(settings, "CELERY_TASK_ALWAYS_EAGER", False):
-            generate_registry_export_siret.delay(siret_export.pk)
-        else:
-            task_chain = chain(
-                generate_registry_export_siret.s(siret_export.pk),
-                refresh_registry_export_siret.s(siret_export.pk),
-                update_siren_export_state.s(registry_v2_export_siren_pk)
-            )
-            task_chain()
-
-
-@app.task(bind=True)
-def generate_registry_export_siret(self, registry_v2_export_siret_pk):
-    """Create registry export for a single SIRET (child of SIREN export)"""
-    geo_retry_delay = min(10 * self.request.retries, 300)
-    max_retries = getattr(self, 'max_retries', 3)  # Default to 3 if not set
-    
-    try:
-        siret_export = RegistryV2ExportSiret.objects.get(pk=registry_v2_export_siret_pk)
-    except RegistryV2ExportSiret.DoesNotExist:
-        logger.error(f"SIRET export {registry_v2_export_siret_pk} not found")
-        return None
-
-    if siret_export.registry_export_id:
-        return registry_v2_export_siret_pk
-
-    now = timezone.now()
-    if now - siret_export.created_at > MAX__GENERATE_DELAY:
-        logger.info("Max delay reached")
-        siret_export.mark_as_failed()
-        return None
-
-    client = httpx.Client(timeout=60)
-    variables = siret_export.get_gql_variables()
-
-    try:
-        res = client.post(
-            url=settings.TD_API_URL,
-            headers={"Authorization": f"Bearer {settings.TD_API_TOKEN}"},
-            json={
-                "query": graphql_generate_registry_export,
-                "variables": variables,
-            },
-        )
-    except httpx.RequestError as e:
-        logger.info(f"HTTP error: {e}")
-        try:
-            if self.request.retries >= max_retries:
-                logger.error(f"Max retries exceeded for SIRET export {registry_v2_export_siret_pk}")
-                siret_export.mark_as_failed()
-                return None
-            raise self.retry(countdown=geo_retry_delay)
-        except MaxRetriesExceededError:
-            logger.error(f"Max retries exceeded for SIRET export {registry_v2_export_siret_pk}")
-            siret_export.mark_as_failed()
-            return None
-
-    resp = res.json()
-
-    # Check for GraphQL errors
-    if resp.get("errors"):
-        logger.error(f"GraphQL errors: {resp.get('errors')}")
-        try:
-            if self.request.retries >= max_retries:
-                logger.error(f"Max retries exceeded for SIRET export {registry_v2_export_siret_pk}")
-                siret_export.mark_as_failed()
-                return None
-            raise self.retry(countdown=geo_retry_delay)
-        except MaxRetriesExceededError:
-            logger.error(f"Max retries exceeded for SIRET export {registry_v2_export_siret_pk}")
-            siret_export.mark_as_failed()
-            return None
-
-    # Check if data is None (GraphQL error response)
-    if resp.get("data") is None:
-        logger.error(f"GraphQL response has no data for SIRET export {registry_v2_export_siret_pk}")
-        try:
-            if self.request.retries >= max_retries:
-                logger.error(f"Max retries exceeded for SIRET export {registry_v2_export_siret_pk}")
-                siret_export.mark_as_failed()
-                return None
-            raise self.retry(countdown=geo_retry_delay)
-        except MaxRetriesExceededError:
-            logger.error(f"Max retries exceeded for SIRET export {registry_v2_export_siret_pk}")
-            siret_export.mark_as_failed()
-            return None
-
-    try:
-        registry_export_id = resp["data"]["generateRegistryV2Export"]["id"]
-        status = resp["data"]["generateRegistryV2Export"]["status"]
-    except (TypeError, KeyError) as e:
-        logger.error(f"Api response error: {e}, response: {resp}")
-        try:
-            if self.request.retries >= max_retries:
-                logger.error(f"Max retries exceeded for SIRET export {registry_v2_export_siret_pk}")
-                siret_export.mark_as_failed()
-                return None
-            raise self.retry(countdown=geo_retry_delay)
-        except MaxRetriesExceededError:
-            logger.error(f"Max retries exceeded for SIRET export {registry_v2_export_siret_pk}")
-            siret_export.mark_as_failed()
-            return None
-
-    siret_export.registry_export_id = registry_export_id
-    siret_export.state = status
-    siret_export.save()
-
-    return registry_v2_export_siret_pk
-
-
-@app.task(bind=True, max_retries=None)
-def refresh_registry_export_siret(self, registry_v2_export_siret_pk):
-    """Refresh status for a single SIRET export"""
-    static_retry_delay = 10
-    geo_retry_delay = min(10 * self.request.retries, 300)
-
-    try:
-        siret_export = RegistryV2ExportSiret.objects.get(pk=registry_v2_export_siret_pk)
-    except RegistryV2ExportSiret.DoesNotExist:
-        if self.request.retries < 3:
-            # retry 2 times with a 1s delay
-            raise self.retry(countdown=1)
-        # really does not exist, exit
-        return None
-
-    if siret_export.state in [
-        RegistryV2ExportState.CANCELED,
-        RegistryV2ExportState.SUCCESSFUL,
-        RegistryV2ExportState.FAILED,
-    ]:
-        return None
-
-    now = timezone.now()
-    if now - siret_export.created_at > MAX__REFRESH_DELAY:
-        logger.info("Max delay reached")
-        siret_export.mark_as_failed()
-        return None
-
-    client = httpx.Client(timeout=10)  # 10 seconds
-
-    try:
-        res = client.post(
-            url=settings.TD_API_URL,
-            headers={"Authorization": f"Bearer {settings.TD_API_TOKEN}"},
-            json={
-                "query": graphql_read_registry_export,
-                "variables": {
-                    "id": siret_export.registry_export_id,
-                },
-            },
-        )
-    except httpx.RequestError:
-        # http error, geometric retry delay
-        logger.info("HTTP error")
-        raise self.retry(countdown=geo_retry_delay)
-
-    if res.status_code == 200:
-        resp = res.json()
-        try:
-            registry_export_state = resp["data"]["registryV2Export"]["status"]
-
-        except (TypeError, KeyError):
-            logger.info("Api error")
-            raise self.retry(countdown=static_retry_delay)
-        if registry_export_state not in [RegistryV2ExportState.PENDING, RegistryV2ExportState.STARTED]:
-            siret_export.state = registry_export_state
-            siret_export.save()
-            return None
-        else:
-            # Registry not ready yet, retry after static_retry_delay
-            logger.info("registry not ready")
-            raise self.retry(countdown=static_retry_delay)
-
-    else:
-        # Api error, geometric retry delay
-        logger.info("Api error")
-        raise self.retry(countdown=geo_retry_delay)
-
 
 @app.task
 def update_siren_export_state(registry_v2_export_siren_pk):

--- a/src/registry/task.py
+++ b/src/registry/task.py
@@ -10,19 +10,35 @@ from config.celery_app import app
 
 from .constants import RegistryV2ExportState
 from .gql import graphql_generate_registry_export, graphql_read_registry_export
-from .models import RegistryV2Export
+from .models import RegistryV2Export, RegistryV2ExportSiren, RegistryV2ExportSiret
 
 logger = logging.getLogger(__name__)
 
 
 def process_export(registry_v2_export_pk):
-    if getattr(settings, "CELERY_TASK_ALWAYS_EAGER", False):
-        # for testing purposes
-        generate_registry_export.delay(registry_v2_export_pk)
-        return
+    """Process export - handles both SIRET and SIREN exports"""
+    # Try to get as SIRET export first (backward compatibility)
+    try:
+        RegistryV2Export.objects.get(pk=registry_v2_export_pk)
+        # Existing SIRET export logic
+        if getattr(settings, "CELERY_TASK_ALWAYS_EAGER", False):
+            generate_registry_export.delay(registry_v2_export_pk)
+            return
 
-    task_chain = chain(generate_registry_export.s(registry_v2_export_pk), refresh_registry_export.s())
-    task_chain()
+        task_chain = chain(generate_registry_export.s(registry_v2_export_pk), refresh_registry_export.s())
+        task_chain()
+        return
+    except RegistryV2Export.DoesNotExist:
+        pass
+
+    # Try as SIREN export
+    try:
+        RegistryV2ExportSiren.objects.get(pk=registry_v2_export_pk)
+        process_siren_export(registry_v2_export_pk)
+        return
+    except RegistryV2ExportSiren.DoesNotExist:
+        logger.error(f"Export {registry_v2_export_pk} not found")
+        raise
 
 
 MAX__GENERATE_DELAY = dt.timedelta(minutes=15)
@@ -145,3 +161,151 @@ def refresh_registry_export(self, registry_v2_export_pk):
         # Api error, geometric retry delay
         logger.info("Api error")
         raise self.retry(countdown=geo_retry_delay)
+
+
+def process_siren_export(registry_v2_export_siren_pk):
+    """Process SIREN export by creating tasks for each SIRET"""
+    siren_export = RegistryV2ExportSiren.objects.get(pk=registry_v2_export_siren_pk)
+    siret_exports = siren_export.siret_exports.all()
+
+    for siret_export in siret_exports:
+        if getattr(settings, "CELERY_TASK_ALWAYS_EAGER", False):
+            generate_registry_export_siret.delay(siret_export.pk)
+        else:
+            task_chain = chain(
+                generate_registry_export_siret.s(siret_export.pk),
+                refresh_registry_export_siret.s(siret_export.pk),
+                update_siren_export_state.s(registry_v2_export_siren_pk)
+            )
+            task_chain()
+
+
+@app.task(bind=True)
+def generate_registry_export_siret(self, registry_v2_export_siret_pk):
+    """Create registry export for a single SIRET (child of SIREN export)"""
+    geo_retry_delay = min(10 * self.request.retries, 300)
+    siret_export = RegistryV2ExportSiret.objects.get(pk=registry_v2_export_siret_pk)
+
+    if siret_export.registry_export_id:
+        return registry_v2_export_siret_pk
+
+    now = timezone.now()
+    if now - siret_export.created_at > MAX__GENERATE_DELAY:
+        logger.info("Max delay reached")
+        siret_export.state = RegistryV2ExportState.FAILED
+        siret_export.save()
+        return None
+
+    client = httpx.Client(timeout=60)
+    variables = siret_export.get_gql_variables()
+
+    try:
+        res = client.post(
+            url=settings.TD_API_URL,
+            headers={"Authorization": f"Bearer {settings.TD_API_TOKEN}"},
+            json={
+                "query": graphql_generate_registry_export,
+                "variables": variables,
+            },
+        )
+    except httpx.RequestError:
+        logger.info("HTTP error")
+        raise self.retry(countdown=geo_retry_delay)
+
+    resp = res.json()
+
+    try:
+        registry_export_id = resp["data"]["generateRegistryV2Export"]["id"]
+        status = resp["data"]["generateRegistryV2Export"]["status"]
+    except (TypeError, KeyError):
+        logger.info("Api response error")
+        raise self.retry(countdown=geo_retry_delay)
+
+    siret_export.registry_export_id = registry_export_id
+    siret_export.state = status
+    siret_export.save()
+
+    return registry_v2_export_siret_pk
+
+
+@app.task(bind=True, max_retries=None)
+def refresh_registry_export_siret(self, registry_v2_export_siret_pk):
+    """Refresh status for a single SIRET export"""
+    static_retry_delay = 10
+    geo_retry_delay = min(10 * self.request.retries, 300)
+
+    try:
+        siret_export = RegistryV2ExportSiret.objects.get(pk=registry_v2_export_siret_pk)
+    except RegistryV2ExportSiret.DoesNotExist:
+        if self.request.retries < 3:
+            # retry 2 times with a 1s delay
+            raise self.retry(countdown=1)
+        # really does not exist, exit
+        return None
+
+    if siret_export.state in [
+        RegistryV2ExportState.CANCELED,
+        RegistryV2ExportState.SUCCESSFUL,
+        RegistryV2ExportState.FAILED,
+    ]:
+        return None
+
+    now = timezone.now()
+    if now - siret_export.created_at > MAX__REFRESH_DELAY:
+        logger.info("Max delay reached")
+        siret_export.mark_as_failed()
+        return None
+
+    client = httpx.Client(timeout=10)  # 10 seconds
+
+    try:
+        res = client.post(
+            url=settings.TD_API_URL,
+            headers={"Authorization": f"Bearer {settings.TD_API_TOKEN}"},
+            json={
+                "query": graphql_read_registry_export,
+                "variables": {
+                    "id": siret_export.registry_export_id,
+                },
+            },
+        )
+    except httpx.RequestError:
+        # http error, geometric retry delay
+        logger.info("HTTP error")
+        raise self.retry(countdown=geo_retry_delay)
+
+    if res.status_code == 200:
+        resp = res.json()
+        try:
+            registry_export_state = resp["data"]["registryV2Export"]["status"]
+
+        except (TypeError, KeyError):
+            logger.info("Api error")
+            raise self.retry(countdown=static_retry_delay)
+        if registry_export_state not in [RegistryV2ExportState.PENDING, RegistryV2ExportState.STARTED]:
+            siret_export.state = registry_export_state
+            siret_export.save()
+            return None
+        else:
+            # Registry not ready yet, retry after static_retry_delay
+            logger.info("registry not ready")
+            raise self.retry(countdown=static_retry_delay)
+
+    else:
+        # Api error, geometric retry delay
+        logger.info("Api error")
+        raise self.retry(countdown=geo_retry_delay)
+
+
+@app.task
+def update_siren_export_state(registry_v2_export_siren_pk):
+    """Update parent SIREN export state based on children"""
+    siren_export = RegistryV2ExportSiren.objects.get(pk=registry_v2_export_siren_pk)
+    siren_export.update_aggregated_state()
+
+    # If not all completed, schedule another check
+    if siren_export.state in [RegistryV2ExportState.PENDING, RegistryV2ExportState.STARTED]:
+        update_siren_export_state.apply_async(
+            args=[registry_v2_export_siren_pk],
+            countdown=10
+        )

--- a/src/registry/task.py
+++ b/src/registry/task.py
@@ -3,6 +3,7 @@ import logging
 
 import httpx
 from celery import chain
+from celery.exceptions import MaxRetriesExceededError
 from django.conf import settings
 from django.utils import timezone
 
@@ -48,7 +49,13 @@ MAX__GENERATE_DELAY = dt.timedelta(minutes=15)
 def generate_registry_export(self, registry_v2_export_pk):
     """Create a registry export on TD api"""
     geo_retry_delay = min(10 * self.request.retries, 300)
-    export = RegistryV2Export.objects.get(pk=registry_v2_export_pk)
+    max_retries = getattr(self, 'max_retries', 3)  # Default to 3 if not set
+    
+    try:
+        export = RegistryV2Export.objects.get(pk=registry_v2_export_pk)
+    except RegistryV2Export.DoesNotExist:
+        logger.error(f"Export {registry_v2_export_pk} not found")
+        return None
 
     # Distant export ID already retrieved
     if export.registry_export_id:
@@ -72,18 +79,64 @@ def generate_registry_export(self, registry_v2_export_pk):
                 "variables": variables,
             },
         )
-    except httpx.RequestError:
-        logger.info("HTTP error")
-        raise self.retry(countdown=geo_retry_delay)
+    except httpx.RequestError as e:
+        logger.info(f"HTTP error: {e}")
+        try:
+            if self.request.retries >= max_retries:
+                logger.error(f"Max retries exceeded for export {registry_v2_export_pk}")
+                export.mark_as_failed()
+                return None
+            raise self.retry(countdown=geo_retry_delay)
+        except MaxRetriesExceededError:
+            logger.error(f"Max retries exceeded for export {registry_v2_export_pk}")
+            export.mark_as_failed()
+            return None
 
     resp = res.json()
+
+    # Check for GraphQL errors
+    if resp.get("errors"):
+        logger.error(f"GraphQL errors: {resp.get('errors')}")
+        try:
+            if self.request.retries >= max_retries:
+                logger.error(f"Max retries exceeded for export {registry_v2_export_pk}")
+                export.mark_as_failed()
+                return None
+            raise self.retry(countdown=geo_retry_delay)
+        except MaxRetriesExceededError:
+            logger.error(f"Max retries exceeded for export {registry_v2_export_pk}")
+            export.mark_as_failed()
+            return None
+
+    # Check if data is None (GraphQL error response)
+    if resp.get("data") is None:
+        logger.error(f"GraphQL response has no data for export {registry_v2_export_pk}")
+        try:
+            if self.request.retries >= max_retries:
+                logger.error(f"Max retries exceeded for export {registry_v2_export_pk}")
+                export.mark_as_failed()
+                return None
+            raise self.retry(countdown=geo_retry_delay)
+        except MaxRetriesExceededError:
+            logger.error(f"Max retries exceeded for export {registry_v2_export_pk}")
+            export.mark_as_failed()
+            return None
 
     try:
         registry_export_id = resp["data"]["generateRegistryV2Export"]["id"]
         status = resp["data"]["generateRegistryV2Export"]["status"]
-    except (TypeError, KeyError):
-        logger.info("Api response error")
-        raise self.retry(countdown=geo_retry_delay)
+    except (TypeError, KeyError) as e:
+        logger.error(f"Api response error: {e}, response: {resp}")
+        try:
+            if self.request.retries >= max_retries:
+                logger.error(f"Max retries exceeded for export {registry_v2_export_pk}")
+                export.mark_as_failed()
+                return None
+            raise self.retry(countdown=geo_retry_delay)
+        except MaxRetriesExceededError:
+            logger.error(f"Max retries exceeded for export {registry_v2_export_pk}")
+            export.mark_as_failed()
+            return None
 
     export.registry_export_id = registry_export_id
     export.state = status
@@ -184,7 +237,13 @@ def process_siren_export(registry_v2_export_siren_pk):
 def generate_registry_export_siret(self, registry_v2_export_siret_pk):
     """Create registry export for a single SIRET (child of SIREN export)"""
     geo_retry_delay = min(10 * self.request.retries, 300)
-    siret_export = RegistryV2ExportSiret.objects.get(pk=registry_v2_export_siret_pk)
+    max_retries = getattr(self, 'max_retries', 3)  # Default to 3 if not set
+    
+    try:
+        siret_export = RegistryV2ExportSiret.objects.get(pk=registry_v2_export_siret_pk)
+    except RegistryV2ExportSiret.DoesNotExist:
+        logger.error(f"SIRET export {registry_v2_export_siret_pk} not found")
+        return None
 
     if siret_export.registry_export_id:
         return registry_v2_export_siret_pk
@@ -192,8 +251,7 @@ def generate_registry_export_siret(self, registry_v2_export_siret_pk):
     now = timezone.now()
     if now - siret_export.created_at > MAX__GENERATE_DELAY:
         logger.info("Max delay reached")
-        siret_export.state = RegistryV2ExportState.FAILED
-        siret_export.save()
+        siret_export.mark_as_failed()
         return None
 
     client = httpx.Client(timeout=60)
@@ -208,18 +266,64 @@ def generate_registry_export_siret(self, registry_v2_export_siret_pk):
                 "variables": variables,
             },
         )
-    except httpx.RequestError:
-        logger.info("HTTP error")
-        raise self.retry(countdown=geo_retry_delay)
+    except httpx.RequestError as e:
+        logger.info(f"HTTP error: {e}")
+        try:
+            if self.request.retries >= max_retries:
+                logger.error(f"Max retries exceeded for SIRET export {registry_v2_export_siret_pk}")
+                siret_export.mark_as_failed()
+                return None
+            raise self.retry(countdown=geo_retry_delay)
+        except MaxRetriesExceededError:
+            logger.error(f"Max retries exceeded for SIRET export {registry_v2_export_siret_pk}")
+            siret_export.mark_as_failed()
+            return None
 
     resp = res.json()
+
+    # Check for GraphQL errors
+    if resp.get("errors"):
+        logger.error(f"GraphQL errors: {resp.get('errors')}")
+        try:
+            if self.request.retries >= max_retries:
+                logger.error(f"Max retries exceeded for SIRET export {registry_v2_export_siret_pk}")
+                siret_export.mark_as_failed()
+                return None
+            raise self.retry(countdown=geo_retry_delay)
+        except MaxRetriesExceededError:
+            logger.error(f"Max retries exceeded for SIRET export {registry_v2_export_siret_pk}")
+            siret_export.mark_as_failed()
+            return None
+
+    # Check if data is None (GraphQL error response)
+    if resp.get("data") is None:
+        logger.error(f"GraphQL response has no data for SIRET export {registry_v2_export_siret_pk}")
+        try:
+            if self.request.retries >= max_retries:
+                logger.error(f"Max retries exceeded for SIRET export {registry_v2_export_siret_pk}")
+                siret_export.mark_as_failed()
+                return None
+            raise self.retry(countdown=geo_retry_delay)
+        except MaxRetriesExceededError:
+            logger.error(f"Max retries exceeded for SIRET export {registry_v2_export_siret_pk}")
+            siret_export.mark_as_failed()
+            return None
 
     try:
         registry_export_id = resp["data"]["generateRegistryV2Export"]["id"]
         status = resp["data"]["generateRegistryV2Export"]["status"]
-    except (TypeError, KeyError):
-        logger.info("Api response error")
-        raise self.retry(countdown=geo_retry_delay)
+    except (TypeError, KeyError) as e:
+        logger.error(f"Api response error: {e}, response: {resp}")
+        try:
+            if self.request.retries >= max_retries:
+                logger.error(f"Max retries exceeded for SIRET export {registry_v2_export_siret_pk}")
+                siret_export.mark_as_failed()
+                return None
+            raise self.retry(countdown=geo_retry_delay)
+        except MaxRetriesExceededError:
+            logger.error(f"Max retries exceeded for SIRET export {registry_v2_export_siret_pk}")
+            siret_export.mark_as_failed()
+            return None
 
     siret_export.registry_export_id = registry_export_id
     siret_export.state = status

--- a/src/registry/tests/test_tasks.py
+++ b/src/registry/tests/test_tasks.py
@@ -7,14 +7,14 @@ from celery.exceptions import Retry
 from registry.constants import RegistryV2DeclarationType, RegistryV2ExportState, RegistryV2WasteCode
 from registry.task import refresh_registry_export
 
-from ..factories import RegistryV2ExportFactory
+from ..factories import RegistryV2ExportSiretFactory
 from ..task import generate_registry_export
 
 pytestmark = pytest.mark.django_db
 
 
 def test_generate_registry_export_success():
-    registry_export = RegistryV2ExportFactory()
+    registry_export = RegistryV2ExportSiretFactory()
     mock_response = {
         "data": {
             "generateRegistryV2Export": {
@@ -43,19 +43,19 @@ def test_generate_registry_export_success():
         request_payload = call_kwargs["json"]
         variables = request_payload["variables"]
         assert variables["siret"] == registry_export.siret
-        assert variables["registryType"] == registry_export.registry_type
-        assert variables["format"] == registry_export.export_format
+        assert variables["registryType"] == registry_export.parent.registry_type
+        assert variables["format"] == registry_export.parent.export_format
 
 
 def test_generate_registry_export_with_advanced_params_success():
-    registry_export = RegistryV2ExportFactory(
-        start_date=dt.datetime.fromisoformat("2024-12-31T23:00:00+00:00"),
-        end_date=dt.datetime.fromisoformat("2025-12-31T23:00:00+00:00"),
-        declaration_type=RegistryV2DeclarationType.BSD,
-        waste_types_dnd=True,
-        waste_types_dd=True,
-        waste_types_texs=True,
-        waste_codes=[RegistryV2WasteCode.WASTE_01_01_01],
+    registry_export = RegistryV2ExportSiretFactory(
+        parent__start_date=dt.datetime.fromisoformat("2024-12-31T23:00:00+00:00"),
+        parent__end_date=dt.datetime.fromisoformat("2025-12-31T23:00:00+00:00"),
+        parent__declaration_type=RegistryV2DeclarationType.BSD,
+        parent__waste_types_dnd=True,
+        parent__waste_types_dd=True,
+        parent__waste_types_texs=True,
+        parent__waste_codes=[RegistryV2WasteCode.WASTE_01_01_01],
     )
     mock_response = {
         "data": {
@@ -99,7 +99,7 @@ def test_generate_registry_export_with_advanced_params_success():
 
 
 def test_generate_registry_export_api_error():
-    registry_export = RegistryV2ExportFactory()
+    registry_export = RegistryV2ExportSiretFactory()
 
     mock_error_response = {"errors": [{"message": "Export generation failed"}]}
 
@@ -122,7 +122,7 @@ def test_generate_registry_export_api_error():
 
 
 def test_generate_registry_export_request_exception():
-    registry_export = RegistryV2ExportFactory()
+    registry_export = RegistryV2ExportSiretFactory()
     with patch("httpx.Client.post") as mock_post:
         mock_post.side_effect = Exception("Network error")
 
@@ -136,7 +136,7 @@ def test_generate_registry_export_request_exception():
 
 
 def test_refresh_registry_export_success():
-    registry_export = RegistryV2ExportFactory(registry_export_id="wxcvbn")
+    registry_export = RegistryV2ExportSiretFactory(registry_export_id="wxcvbn")
 
     mock_response = {
         "data": {
@@ -169,7 +169,7 @@ def test_refresh_registry_export_success():
 
 
 def test_refresh_registry_export_in_progress():
-    registry_export = RegistryV2ExportFactory(registry_export_id="wxcvbn")
+    registry_export = RegistryV2ExportSiretFactory(registry_export_id="wxcvbn")
 
     mock_response = {
         "data": {
@@ -198,7 +198,7 @@ def test_refresh_registry_export_in_progress():
 
 
 def test_refresh_registry_export_failed():
-    registry_export = RegistryV2ExportFactory(registry_export_id="wxcvbn")
+    registry_export = RegistryV2ExportSiretFactory(registry_export_id="wxcvbn")
 
     mock_response = {
         "data": {
@@ -234,7 +234,7 @@ def test_refresh_registry_export_failed():
 
 
 def test_refresh_registry_export_request_exception():
-    registry_export = RegistryV2ExportFactory(registry_export_id="wxcvbn")
+    registry_export = RegistryV2ExportSiretFactory(registry_export_id="wxcvbn")
 
     with patch("httpx.Client.post") as mock_post:
         mock_post.side_effect = Exception("Network error")

--- a/src/registry/tests/test_views.py
+++ b/src/registry/tests/test_views.py
@@ -1,10 +1,12 @@
 import datetime as dt
+import io
 from unittest.mock import patch
 
 import pytest
 from django.urls import reverse
 
-from ..factories import RegistryV2ExportFactory
+from ..constants import RegistryV2ExportState
+from ..factories import RegistryV2ExportFactory, RegistryV2ExportSirenFactory, RegistryV2ExportSiretFactory
 from ..models import RegistryV2Export
 
 pytestmark = pytest.mark.django_db
@@ -266,3 +268,103 @@ def test_registry_v2_retrieve_missing_data(
         registry_export.refresh_from_db()
 
         assert registry_export.state == "PENDING"
+
+
+def test_registry_v2_retrieve_siren_success(verified_user):
+    """SIREN download returns a ZIP with one file per SIRET."""
+    import zipfile as zf
+
+    siren_export = RegistryV2ExportSirenFactory(created_by=verified_user.user, export_format="CSV")
+    siret1 = RegistryV2ExportSiretFactory(
+        parent=siren_export, siret="11111111111111", state=RegistryV2ExportState.SUCCESSFUL, registry_export_id="exp-1"
+    )
+    siret2 = RegistryV2ExportSiretFactory(
+        parent=siren_export, siret="22222222222222", state=RegistryV2ExportState.SUCCESSFUL, registry_export_id="exp-2"
+    )
+
+    mock_graphql_response = {
+        "data": {"registryV2ExportDownloadSignedUrl": {"signedUrl": "https://s3.example.com/file"}}
+    }
+    fake_file_content = b"col1,col2\nval1,val2"
+
+    with patch("httpx.Client.post") as mock_post, patch("httpx.get") as mock_get:
+        mock_post.return_value.json.return_value = mock_graphql_response
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.content = fake_file_content
+        mock_get.return_value.raise_for_status = lambda: None
+
+        url = reverse("registry_v2_retrieve", args=[siren_export.pk])
+        response = verified_user.post(url)
+
+    assert response.status_code == 200
+    assert response["Content-Type"] == "application/zip"
+    assert f"{siren_export.siren}_registre.zip" in response["Content-Disposition"]
+
+    zip_bytes = io.BytesIO(response.content)
+    with zf.ZipFile(zip_bytes) as z:
+        names = z.namelist()
+        assert f"{siret1.siret}.csv" in names
+        assert f"{siret2.siret}.csv" in names
+        assert z.read(f"{siret1.siret}.csv") == fake_file_content
+        assert z.read(f"{siret2.siret}.csv") == fake_file_content
+
+
+def test_registry_v2_retrieve_siren_no_completed_exports(verified_user):
+    """SIREN download with no SUCCESSFUL children redirects with error message."""
+    siren_export = RegistryV2ExportSirenFactory(created_by=verified_user.user, total_sirets=2, completed_sirets=0)
+    RegistryV2ExportSiretFactory(parent=siren_export, state=RegistryV2ExportState.PENDING)
+
+    url = reverse("registry_v2_retrieve", args=[siren_export.pk])
+    response = verified_user.post(url, follow=True)
+
+    assert response.status_code == 200
+    assert response.redirect_chain[-1][0] == reverse("registry_v2_prepare")
+    messages_list = list(response.context["messages"])
+    assert any("Aucun export disponible" in str(m) for m in messages_list)
+
+
+def test_registry_v2_retrieve_siren_partial_failure(verified_user):
+    """SIREN download with some failed child downloads still returns a ZIP with successes."""
+    import zipfile as zf
+
+    siren_export = RegistryV2ExportSirenFactory(created_by=verified_user.user, export_format="CSV")
+    siret_ok = RegistryV2ExportSiretFactory(
+        parent=siren_export, siret="33333333333333", state=RegistryV2ExportState.SUCCESSFUL, registry_export_id="ok"
+    )
+    RegistryV2ExportSiretFactory(
+        parent=siren_export, siret="44444444444444", state=RegistryV2ExportState.SUCCESSFUL, registry_export_id="fail"
+    )
+
+    fake_file_content = b"ok_data"
+
+    # Return a signed URL only for the "ok" export_id; return an error response for "fail"
+    def fake_post(url, **kwargs):
+        export_id = kwargs["json"]["variables"]["exportId"]
+        mock = type("R", (), {})()
+        if export_id == "ok":
+            mock.json = lambda: {
+                "data": {"registryV2ExportDownloadSignedUrl": {"signedUrl": "https://s3.example.com/file"}}
+            }
+        else:
+            mock.json = lambda: {"errors": [{"message": "not found"}]}
+        return mock
+
+    def fake_get(url, **kwargs):
+        mock = type("R", (), {})()
+        mock.status_code = 200
+        mock.content = fake_file_content
+        mock.raise_for_status = lambda: None
+        return mock
+
+    with patch("httpx.Client.post", side_effect=fake_post), patch("httpx.get", side_effect=fake_get):
+        url = reverse("registry_v2_retrieve", args=[siren_export.pk])
+        response = verified_user.post(url)
+
+    assert response.status_code == 200
+    assert response["Content-Type"] == "application/zip"
+
+    zip_bytes = io.BytesIO(response.content)
+    with zf.ZipFile(zip_bytes) as z:
+        names = z.namelist()
+        assert f"{siret_ok.siret}.csv" in names
+        assert len(names) == 1

--- a/src/registry/tests/test_views.py
+++ b/src/registry/tests/test_views.py
@@ -4,7 +4,6 @@ from unittest.mock import patch
 import pytest
 from django.urls import reverse
 
-from ..constants import RegistryV2ExportState
 from ..factories import RegistryV2ExportFactory
 from ..models import RegistryV2Export
 
@@ -60,21 +59,12 @@ def test_registry_v2_prepare_v2(get_client):
     "get_client", ["verified_client", "logged_monaiot_client", "logged_proconnect_client"], indirect=True
 )
 def test_registry_prepare_v2_post(get_client):
-    mock_response = {
-        "data": {
-            "generateRegistryV2Export": {
-                "id": "mock-export-id-123",
-                "status": RegistryV2ExportState.STARTED,
-            }
-        }
-    }
     url = reverse("registry_v2_prepare")
-    with patch("httpx.Client.post") as mock_post:
-        mock_post.return_value.json.return_value = mock_response
-
+    with patch("registry.views.process_export"):
         res = get_client.post(
             url,
             data={
+                "identifier_type": "SIRET",
                 "siret": "51212357100030",
                 "registry_type": "INCOMING",
                 "export_format": "CSV",
@@ -92,18 +82,17 @@ def test_registry_prepare_v2_post(get_client):
     reg = RegistryV2Export.objects.first()
     assert reg.pk
     assert reg.siret == "51212357100030"
-    assert reg.state == "STARTED"
+    assert reg.state == "PENDING"
 
 
 def test_registry_v2_prepare_form_valid_calls_task(verified_user):
-    """Test that form_valid method calls generate_registry_export.delay with correct args."""
+    """Test that form_valid method calls process_export with correct args."""
 
-    # Mock the delay method of the task
-    with patch("registry.task.generate_registry_export.delay") as mock_delay:
-        # Get the form submission URL
+    with patch("registry.views.process_export") as mock_process:
         url = reverse("registry_v2_prepare")
 
         form_data = {
+            "identifier_type": "SIRET",
             "siret": "12345678900000",
             "registry_type": "INCOMING",
             "declaration_type": "ALL",
@@ -128,8 +117,8 @@ def test_registry_v2_prepare_form_valid_calls_task(verified_user):
         assert export.registry_type == form_data["registry_type"]
         assert export.state == "PENDING"
 
-        # Assert that the task was called with the correct argument
-        mock_delay.assert_called_once_with(export.pk)
+        # Assert that process_export was called with the correct argument
+        mock_process.assert_called_once_with(export.pk)
 
 
 def test_registry_v2_list_content_deny_anon(anon_client):
@@ -174,7 +163,7 @@ def test_registry_v2_retrieve_deny_observatoire(verified_observatoire):
 def test_registry_v2_retrieve_success(verified_user):
     """Test successful retrieval of signed URL."""
 
-    registry_export = RegistryV2ExportFactory()
+    registry_export = RegistryV2ExportFactory(created_by=verified_user.user)
     # Mock API response with a signed URL
     mock_response = {
         "data": {"registryV2ExportDownloadSignedUrl": {"signedUrl": "https://test-signed-url.example.com/download"}}
@@ -209,7 +198,7 @@ def test_registry_v2_retrieve_success(verified_user):
 def test_registry_v2_retrieve_api_error(verified_user):
     """Test handling of API error response."""
 
-    registry_export = RegistryV2ExportFactory()
+    registry_export = RegistryV2ExportFactory(created_by=verified_user.user)
     # Mock API error response
     mock_response = {"errors": [{"message": "Error retrieving download URL"}]}
 
@@ -237,7 +226,7 @@ def test_registry_v2_retrieve_missing_data(
     """Test handling of missing data in API response."""
     # Mock response with missing data structure
 
-    registry_export = RegistryV2ExportFactory()
+    registry_export = RegistryV2ExportFactory(created_by=verified_user.user)
     mock_response = {
         "data": {}  # Empty data without the expected fields
     }
@@ -265,7 +254,7 @@ def test_registry_v2_retrieve_missing_data(
     ):
         """Test handling of HTTP request exceptions."""
 
-        registry_export = RegistryV2ExportFactory()
+        registry_export = RegistryV2ExportFactory(created_by=verified_user.user)
         with patch("httpx.Client.post") as mock_post:
             # Configure the mock to raise an exception
             mock_post.side_effect = Exception("Network error")

--- a/src/registry/tests/test_views.py
+++ b/src/registry/tests/test_views.py
@@ -251,23 +251,24 @@ def test_registry_v2_retrieve_missing_data(
         assert len(messages) == 1
         assert "Erreur, le registre n'a pu être téléchargé" in str(messages[0])
 
-    def test_registry_v2_retrieve_request_exception(
-        verified_user,
-    ):
-        """Test handling of HTTP request exceptions."""
 
-        registry_export = RegistryV2ExportFactory(created_by=verified_user.user)
-        with patch("httpx.Client.post") as mock_post:
-            # Configure the mock to raise an exception
-            mock_post.side_effect = Exception("Network error")
+def test_registry_v2_retrieve_request_exception(
+    verified_user,
+):
+    """Test handling of HTTP request exceptions."""
 
-            # Make the request
-            url = reverse("registry_v2_retrieve", args=[registry_export.pk])
-            with pytest.raises(Exception):
-                verified_user.post(url)
-        registry_export.refresh_from_db()
+    registry_export = RegistryV2ExportFactory(created_by=verified_user.user)
+    with patch("httpx.Client.post") as mock_post:
+        # Configure the mock to raise an exception
+        mock_post.side_effect = Exception("Network error")
 
-        assert registry_export.state == "PENDING"
+        # Make the request
+        url = reverse("registry_v2_retrieve", args=[registry_export.pk])
+        with pytest.raises(Exception):
+            verified_user.post(url)
+    registry_export.refresh_from_db()
+
+    assert registry_export.state == "PENDING"
 
 
 def test_registry_v2_retrieve_siren_success(verified_user):

--- a/src/registry/views.py
+++ b/src/registry/views.py
@@ -166,7 +166,7 @@ class RegistryV2Retrieve(FullyLoggedMixin, FormView):
             return (siret_export.siret, response.content)
         except Exception:
             return None
-            
+
     def _handle_siren_download(self, siren_export):
         """Handle download for SIREN export — returns a ZIP of all completed SIRET exports."""
         completed_exports = list(siren_export.siret_exports.filter(state=RegistryV2ExportState.SUCCESSFUL))
@@ -179,8 +179,6 @@ class RegistryV2Retrieve(FullyLoggedMixin, FormView):
             return HttpResponseRedirect(reverse_lazy("registry_v2_prepare"))
 
         ext = siren_export.export_format.lower()  # "csv" or "xlsx"
-
-
 
         with ThreadPoolExecutor(max_workers=10) as executor:
             results = list(executor.map(self._fetch_file, completed_exports))

--- a/src/registry/views.py
+++ b/src/registry/views.py
@@ -1,9 +1,12 @@
 import datetime as dt
+import io
+import zipfile
+from concurrent.futures import ThreadPoolExecutor
 
 import httpx
 from django.conf import settings
 from django.contrib import messages
-from django.http import HttpResponseRedirect
+from django.http import HttpResponse, HttpResponseRedirect
 from django.views.generic import CreateView, FormView, ListView
 from rest_framework.reverse import reverse_lazy
 
@@ -152,51 +155,70 @@ class RegistryV2Retrieve(FullyLoggedMixin, FormView):
             messages.error(self.request, "Export introuvable")
             return HttpResponseRedirect(reverse_lazy("registry_v2_prepare"))
 
+    def _fetch_file(self, siret_export):
+        """Returns (siret, bytes) or None on failure."""
+        url = self._fetch_signed_url(siret_export.registry_export_id)
+        if url is None:
+            return None
+        try:
+            response = httpx.get(url, timeout=60, follow_redirects=True)
+            response.raise_for_status()
+            return (siret_export.siret, response.content)
+        except Exception:
+            return None
+            
     def _handle_siren_download(self, siren_export):
-        """Handle download for SIREN export"""
-        completed_exports = siren_export.siret_exports.filter(state=RegistryV2ExportState.SUCCESSFUL)
+        """Handle download for SIREN export — returns a ZIP of all completed SIRET exports."""
+        completed_exports = list(siren_export.siret_exports.filter(state=RegistryV2ExportState.SUCCESSFUL))
 
-        if not completed_exports.exists():
+        if not completed_exports:
             messages.error(
                 self.request,
                 f"Aucun export disponible ({siren_export.completed_sirets}/{siren_export.total_sirets} terminés)",
             )
             return HttpResponseRedirect(reverse_lazy("registry_v2_prepare"))
 
-        # For now, redirect to first completed export
-        # TODO: Implement ZIP download or combined file
-        first_export = completed_exports.first()
-        return self._handle_siret_download_via_siret_export(first_export)
+        ext = siren_export.export_format.lower()  # "csv" or "xlsx"
 
-    def _handle_siret_download(self, export):
-        """Handle download for single SIRET export"""
+
+
+        with ThreadPoolExecutor(max_workers=10) as executor:
+            results = list(executor.map(self._fetch_file, completed_exports))
+
+        files = [r for r in results if r is not None]
+        if not files:
+            messages.error(self.request, "Erreur lors du téléchargement des exports")
+            return HttpResponseRedirect(reverse_lazy("registry_v2_prepare"))
+
+        zip_buffer = io.BytesIO()
+        with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zf:
+            for siret, content in files:
+                zf.writestr(f"{siret}.{ext}", content)
+
+        response = HttpResponse(zip_buffer.getvalue(), content_type="application/zip")
+        response["Content-Disposition"] = f'attachment; filename="{siren_export.siren}_registre.zip"'
+        return response
+
+    def _fetch_signed_url(self, registry_export_id: str) -> str | None:
+        """Return signed download URL from Trackdéchets API, or None on error."""
         client = httpx.Client(timeout=60)
-
         res = client.post(
             url=settings.TD_API_URL,
             headers={"Authorization": f"Bearer {settings.TD_API_TOKEN}"},
             json={
                 "query": graphql_registry_V2_export_download_signed_url,
-                "variables": {
-                    "exportId": export.registry_export_id,
-                },
+                "variables": {"exportId": registry_export_id},
             },
         )
-        resp = res.json()
         try:
-            url = resp["data"]["registryV2ExportDownloadSignedUrl"]["signedUrl"]
+            return res.json()["data"]["registryV2ExportDownloadSignedUrl"]["signedUrl"]
         except (TypeError, KeyError):
+            return None
+
+    def _handle_siret_download(self, export):
+        """Handle download for single SIRET export"""
+        url = self._fetch_signed_url(export.registry_export_id)
+        if url is None:
             messages.add_message(self.request, messages.ERROR, "Erreur, le registre n'a pu être téléchargé")
             return HttpResponseRedirect(reverse_lazy("registry_v2_prepare"))
         return HttpResponseRedirect(url)
-
-    def _handle_siret_download_via_siret_export(self, siret_export):
-        """Handle download for RegistryV2ExportSiret (child of SIREN)"""
-
-        # Create a temporary export-like object for download
-        class TempExport:
-            def __init__(self, registry_export_id):
-                self.registry_export_id = registry_export_id
-
-        temp_export = TempExport(siret_export.registry_export_id)
-        return self._handle_siret_download(temp_export)

--- a/src/registry/views.py
+++ b/src/registry/views.py
@@ -14,8 +14,9 @@ from data_exports.views import DummyForm
 
 from .forms import RegistryV2PrepareForm
 from .gql import graphql_registry_V2_export_download_signed_url
-from .models import RegistryV2Export
+from .models import RegistryV2Export, RegistryV2ExportSiren
 from .task import process_export
+from .constants import RegistryV2ExportState
 
 
 class RegistryDownloadException(Exception):
@@ -56,16 +57,49 @@ class RegistryV2Prepare(FullyLoggedMixin, CreateView):
 
 
 class RegistryV2ListContent(FullyLoggedMixin, ListView):
+    """List exports - shows both SIRET and SIREN exports"""
     template_name = "registry/fragments/_registry_v2_list_content.html"
     allowed_user_categories = PERMS_SHEET_AND_REGISTRY
-    model = RegistryV2Export
     context_object_name = "exports"
 
     def get_queryset(self):
-        return super().get_queryset().filter(created_by=self.request.user)[:HISTORY_SIZE]
+        """Get both SIRET and SIREN exports, combine and sort by created_at"""
+        # Get SIRET exports
+        siret_exports = RegistryV2Export.objects.filter(
+            created_by=self.request.user
+        ).values(
+            'id', 'siret', 'state', 'created_at', 'export_format', 
+            'registry_type', 'declaration_type', 'start_date', 'end_date'
+        )
+        
+        # Get SIREN exports
+        siren_exports = RegistryV2ExportSiren.objects.filter(
+            created_by=self.request.user
+        ).values(
+            'id', 'siren', 'state', 'created_at', 'export_format', 
+            'registry_type', 'declaration_type', 'start_date', 'end_date',
+            'total_sirets', 'completed_sirets'
+        )
+        
+        # Combine and mark with type indicator
+        combined = []
+        for export in siret_exports:
+            export['type'] = 'SIRET'
+            export['identifier'] = export['siret']
+            combined.append(export)
+        
+        for export in siren_exports:
+            export['type'] = 'SIREN'
+            export['identifier'] = export['siren']
+            combined.append(export)
+        
+        # Sort by created_at descending and limit to HISTORY_SIZE
+        combined.sort(key=lambda x: x['created_at'], reverse=True)
+        return combined[:HISTORY_SIZE]
 
 
 class RegistryV2Retrieve(FullyLoggedMixin, FormView):
+    """Download export - handles both SIRET and SIREN exports"""
     template_name = "registry/fragments/_registry_v2_list_content.html"
     form_class = DummyForm
     success_url = None
@@ -73,10 +107,50 @@ class RegistryV2Retrieve(FullyLoggedMixin, FormView):
 
     def form_valid(self, form):
         registry_pk = self.kwargs.get("registry_pk")
-        export = RegistryV2Export.objects.get(pk=registry_pk)
-
-        client = httpx.Client(timeout=60)  # 60 seconds
-
+        
+        # Try SIREN export first
+        try:
+            siren_export = RegistryV2ExportSiren.objects.get(
+                pk=registry_pk,
+                created_by=self.request.user
+            )
+            return self._handle_siren_download(siren_export)
+        except RegistryV2ExportSiren.DoesNotExist:
+            pass
+        
+        # Fallback to SIRET export
+        try:
+            export = RegistryV2Export.objects.get(
+                pk=registry_pk,
+                created_by=self.request.user
+            )
+            return self._handle_siret_download(export)
+        except RegistryV2Export.DoesNotExist:
+            messages.error(self.request, "Export introuvable")
+            return HttpResponseRedirect(reverse_lazy("registry_v2_prepare"))
+    
+    def _handle_siren_download(self, siren_export):
+        """Handle download for SIREN export"""
+        completed_exports = siren_export.siret_exports.filter(
+            state=RegistryV2ExportState.SUCCESSFUL
+        )
+        
+        if not completed_exports.exists():
+            messages.error(
+                self.request,
+                f"Aucun export disponible ({siren_export.completed_sirets}/{siren_export.total_sirets} terminés)"
+            )
+            return HttpResponseRedirect(reverse_lazy("registry_v2_prepare"))
+        
+        # For now, redirect to first completed export
+        # TODO: Implement ZIP download or combined file
+        first_export = completed_exports.first()
+        return self._handle_siret_download_via_siret_export(first_export)
+    
+    def _handle_siret_download(self, export):
+        """Handle download for single SIRET export"""
+        client = httpx.Client(timeout=60)
+        
         res = client.post(
             url=settings.TD_API_URL,
             headers={"Authorization": f"Bearer {settings.TD_API_TOKEN}"},
@@ -94,3 +168,13 @@ class RegistryV2Retrieve(FullyLoggedMixin, FormView):
             messages.add_message(self.request, messages.ERROR, "Erreur, le registre n'a pu être téléchargé")
             return HttpResponseRedirect(reverse_lazy("registry_v2_prepare"))
         return HttpResponseRedirect(url)
+    
+    def _handle_siret_download_via_siret_export(self, siret_export):
+        """Handle download for RegistryV2ExportSiret (child of SIREN)"""
+        # Create a temporary export-like object for download
+        class TempExport:
+            def __init__(self, registry_export_id):
+                self.registry_export_id = registry_export_id
+        
+        temp_export = TempExport(siret_export.registry_export_id)
+        return self._handle_siret_download(temp_export)

--- a/src/registry/views.py
+++ b/src/registry/views.py
@@ -16,7 +16,11 @@ from .forms import RegistryV2PrepareForm
 from .gql import graphql_registry_V2_export_download_signed_url
 from .models import RegistryV2Export, RegistryV2ExportSiren
 from .task import process_export
-from .constants import RegistryV2ExportState
+from .constants import (
+    RegistryV2DeclarationType,
+    RegistryV2ExportState,
+    RegistryV2ExportType,
+)
 
 
 class RegistryDownloadException(Exception):
@@ -81,16 +85,24 @@ class RegistryV2ListContent(FullyLoggedMixin, ListView):
             'total_sirets', 'completed_sirets'
         )
         
+        # Create lookup dictionaries for display labels
+        registry_type_labels = {choice[0]: choice[1] for choice in RegistryV2ExportType.choices}
+        declaration_type_labels = {choice[0]: choice[1] for choice in RegistryV2DeclarationType.choices}
+        
         # Combine and mark with type indicator
         combined = []
         for export in siret_exports:
             export['type'] = 'SIRET'
             export['identifier'] = export['siret']
+            export['registry_type_display'] = registry_type_labels.get(export['registry_type'], export['registry_type'])
+            export['declaration_type_display'] = declaration_type_labels.get(export['declaration_type'], export['declaration_type'])
             combined.append(export)
         
         for export in siren_exports:
             export['type'] = 'SIREN'
             export['identifier'] = export['siren']
+            export['registry_type_display'] = registry_type_labels.get(export['registry_type'], export['registry_type'])
+            export['declaration_type_display'] = declaration_type_labels.get(export['declaration_type'], export['declaration_type'])
             combined.append(export)
         
         # Sort by created_at descending and limit to HISTORY_SIZE

--- a/src/registry/views.py
+++ b/src/registry/views.py
@@ -12,15 +12,11 @@ from common.constants import HISTORY_SIZE
 from common.mixins import FullyLoggedMixin
 from data_exports.views import DummyForm
 
+from .constants import RegistryV2DeclarationType, RegistryV2ExportState, RegistryV2ExportType
 from .forms import RegistryV2PrepareForm
 from .gql import graphql_registry_V2_export_download_signed_url
 from .models import RegistryV2Export, RegistryV2ExportSiren
 from .task import process_export
-from .constants import (
-    RegistryV2DeclarationType,
-    RegistryV2ExportState,
-    RegistryV2ExportType,
-)
 
 
 class RegistryDownloadException(Exception):
@@ -62,6 +58,7 @@ class RegistryV2Prepare(FullyLoggedMixin, CreateView):
 
 class RegistryV2ListContent(FullyLoggedMixin, ListView):
     """List exports - shows both SIRET and SIREN exports"""
+
     template_name = "registry/fragments/_registry_v2_list_content.html"
     allowed_user_categories = PERMS_SHEET_AND_REGISTRY
     context_object_name = "exports"
@@ -69,49 +66,69 @@ class RegistryV2ListContent(FullyLoggedMixin, ListView):
     def get_queryset(self):
         """Get both SIRET and SIREN exports, combine and sort by created_at"""
         # Get SIRET exports
-        siret_exports = RegistryV2Export.objects.filter(
-            created_by=self.request.user
-        ).values(
-            'id', 'siret', 'state', 'created_at', 'export_format', 
-            'registry_type', 'declaration_type', 'start_date', 'end_date'
+        siret_exports = RegistryV2Export.objects.filter(created_by=self.request.user).values(
+            "id",
+            "siret",
+            "state",
+            "created_at",
+            "export_format",
+            "registry_type",
+            "declaration_type",
+            "start_date",
+            "end_date",
         )
-        
+
         # Get SIREN exports
-        siren_exports = RegistryV2ExportSiren.objects.filter(
-            created_by=self.request.user
-        ).values(
-            'id', 'siren', 'state', 'created_at', 'export_format', 
-            'registry_type', 'declaration_type', 'start_date', 'end_date',
-            'total_sirets', 'completed_sirets'
+        siren_exports = RegistryV2ExportSiren.objects.filter(created_by=self.request.user).values(
+            "id",
+            "siren",
+            "state",
+            "created_at",
+            "export_format",
+            "registry_type",
+            "declaration_type",
+            "start_date",
+            "end_date",
+            "total_sirets",
+            "completed_sirets",
         )
-        
+
         # Create lookup dictionaries for display labels
         registry_type_labels = {choice[0]: choice[1] for choice in RegistryV2ExportType.choices}
         declaration_type_labels = {choice[0]: choice[1] for choice in RegistryV2DeclarationType.choices}
-        
+
         # Combine and mark with type indicator
         combined = []
         for export in siret_exports:
-            export['type'] = 'SIRET'
-            export['identifier'] = export['siret']
-            export['registry_type_display'] = registry_type_labels.get(export['registry_type'], export['registry_type'])
-            export['declaration_type_display'] = declaration_type_labels.get(export['declaration_type'], export['declaration_type'])
+            export["type"] = "SIRET"
+            export["identifier"] = export["siret"]
+            export["registry_type_display"] = registry_type_labels.get(
+                export["registry_type"], export["registry_type"]
+            )
+            export["declaration_type_display"] = declaration_type_labels.get(
+                export["declaration_type"], export["declaration_type"]
+            )
             combined.append(export)
-        
+
         for export in siren_exports:
-            export['type'] = 'SIREN'
-            export['identifier'] = export['siren']
-            export['registry_type_display'] = registry_type_labels.get(export['registry_type'], export['registry_type'])
-            export['declaration_type_display'] = declaration_type_labels.get(export['declaration_type'], export['declaration_type'])
+            export["type"] = "SIREN"
+            export["identifier"] = export["siren"]
+            export["registry_type_display"] = registry_type_labels.get(
+                export["registry_type"], export["registry_type"]
+            )
+            export["declaration_type_display"] = declaration_type_labels.get(
+                export["declaration_type"], export["declaration_type"]
+            )
             combined.append(export)
-        
+
         # Sort by created_at descending and limit to HISTORY_SIZE
-        combined.sort(key=lambda x: x['created_at'], reverse=True)
+        combined.sort(key=lambda x: x["created_at"], reverse=True)
         return combined[:HISTORY_SIZE]
 
 
 class RegistryV2Retrieve(FullyLoggedMixin, FormView):
     """Download export - handles both SIRET and SIREN exports"""
+
     template_name = "registry/fragments/_registry_v2_list_content.html"
     form_class = DummyForm
     success_url = None
@@ -119,50 +136,42 @@ class RegistryV2Retrieve(FullyLoggedMixin, FormView):
 
     def form_valid(self, form):
         registry_pk = self.kwargs.get("registry_pk")
-        
+
         # Try SIREN export first
         try:
-            siren_export = RegistryV2ExportSiren.objects.get(
-                pk=registry_pk,
-                created_by=self.request.user
-            )
+            siren_export = RegistryV2ExportSiren.objects.get(pk=registry_pk, created_by=self.request.user)
             return self._handle_siren_download(siren_export)
         except RegistryV2ExportSiren.DoesNotExist:
             pass
-        
+
         # Fallback to SIRET export
         try:
-            export = RegistryV2Export.objects.get(
-                pk=registry_pk,
-                created_by=self.request.user
-            )
+            export = RegistryV2Export.objects.get(pk=registry_pk, created_by=self.request.user)
             return self._handle_siret_download(export)
         except RegistryV2Export.DoesNotExist:
             messages.error(self.request, "Export introuvable")
             return HttpResponseRedirect(reverse_lazy("registry_v2_prepare"))
-    
+
     def _handle_siren_download(self, siren_export):
         """Handle download for SIREN export"""
-        completed_exports = siren_export.siret_exports.filter(
-            state=RegistryV2ExportState.SUCCESSFUL
-        )
-        
+        completed_exports = siren_export.siret_exports.filter(state=RegistryV2ExportState.SUCCESSFUL)
+
         if not completed_exports.exists():
             messages.error(
                 self.request,
-                f"Aucun export disponible ({siren_export.completed_sirets}/{siren_export.total_sirets} terminés)"
+                f"Aucun export disponible ({siren_export.completed_sirets}/{siren_export.total_sirets} terminés)",
             )
             return HttpResponseRedirect(reverse_lazy("registry_v2_prepare"))
-        
+
         # For now, redirect to first completed export
         # TODO: Implement ZIP download or combined file
         first_export = completed_exports.first()
         return self._handle_siret_download_via_siret_export(first_export)
-    
+
     def _handle_siret_download(self, export):
         """Handle download for single SIRET export"""
         client = httpx.Client(timeout=60)
-        
+
         res = client.post(
             url=settings.TD_API_URL,
             headers={"Authorization": f"Bearer {settings.TD_API_TOKEN}"},
@@ -180,13 +189,14 @@ class RegistryV2Retrieve(FullyLoggedMixin, FormView):
             messages.add_message(self.request, messages.ERROR, "Erreur, le registre n'a pu être téléchargé")
             return HttpResponseRedirect(reverse_lazy("registry_v2_prepare"))
         return HttpResponseRedirect(url)
-    
+
     def _handle_siret_download_via_siret_export(self, siret_export):
         """Handle download for RegistryV2ExportSiret (child of SIREN)"""
+
         # Create a temporary export-like object for download
         class TempExport:
             def __init__(self, registry_export_id):
                 self.registry_export_id = registry_export_id
-        
+
         temp_export = TempExport(siret_export.registry_export_id)
         return self._handle_siret_download(temp_export)

--- a/src/registry/views.py
+++ b/src/registry/views.py
@@ -49,14 +49,10 @@ class RegistryV2Prepare(FullyLoggedMixin, CreateView):
         label_prev_year = year - 1
         return super().get_context_data(**kwargs, label_this_year=label_this_year, label_prev_year=label_prev_year)
 
-    def form_valid(
-        self,
-        form,
-    ):
-        res = super().form_valid(form)
-
+    def form_valid(self, form):
+        self.object = form.save()
         process_export(self.object.pk)
-        return res
+        return HttpResponseRedirect(self.get_success_url())
 
 
 class RegistryV2ListContent(FullyLoggedMixin, ListView):

--- a/src/sheets/data_processing.py
+++ b/src/sheets/data_processing.py
@@ -19,7 +19,6 @@ from .constants import (
     WASTE_ORIGIN_TYPES,
 )
 from .data_extract import load_departements_regions_data, load_waste_code_data
-from .data_extract import load_departements_regions_data, load_waste_code_data
 from .data_extraction import (
     build_auto_approved_revision_bsda_query,
     build_auto_approved_revision_bsdd_query,

--- a/src/sheets/data_processing.py
+++ b/src/sheets/data_processing.py
@@ -19,6 +19,7 @@ from .constants import (
     WASTE_ORIGIN_TYPES,
 )
 from .data_extract import load_departements_regions_data, load_waste_code_data
+from .data_extract import load_departements_regions_data, load_waste_code_data
 from .data_extraction import (
     build_auto_approved_revision_bsda_query,
     build_auto_approved_revision_bsdd_query,

--- a/src/sheets/queries.py
+++ b/src/sheets/queries.py
@@ -608,6 +608,18 @@ where
     substring(c.siret,1,9) = substring(:siret,1,9)
 """
 
+sql_get_linked_companies_data_from_siren = """
+select
+    siret,
+    created_at,
+    name,
+    address
+from
+    trusted_zone_trackdechets.company c
+where
+    substring(c.siret,1,9) = substring(:siren,1,9)
+"""
+
 sql_get_gistrid_data = """
 select
     numero_notification,

--- a/src/templates/registry/fragments/_registry_v2_list_content.html
+++ b/src/templates/registry/fragments/_registry_v2_list_content.html
@@ -18,24 +18,44 @@
         <tr>
             <td>
                 <div>{{ export.created_at }}</div>
-
-
-             {% registry_badge_class export %}
-
+                <p class="fr-badge fr-badge--sm 
+                    {% if export.state == 'SUCCESSFUL' %}fr-badge--success
+                    {% elif export.state == 'FAILED' or export.state == 'CANCELED' %}fr-badge--error
+                    {% elif export.state == 'STARTED' %}fr-badge--info
+                    {% else %}fr-badge--new{% endif %}">
+                    {% if export.state == 'SUCCESSFUL' %}Terminé
+                    {% elif export.state == 'FAILED' %}Erreur
+                    {% elif export.state == 'CANCELED' %}Annulé
+                    {% elif export.state == 'STARTED' %}En cours
+                    {% else %}En attente{% endif %}
+                </p>
             </td>
-            <td>{{ export.siret }}</td>
-            <td> {{ export.get_registry_type_display }}</td>
-            <td> {{ export.get_declaration_type_display }}</td>
+            <td>
+                {% if export.type == 'SIREN' %}
+                    <strong>SIREN:</strong> {{ export.identifier }}
+                    {% if export.total_sirets %}
+                        <br><small class="fr-text--sm">({{ export.completed_sirets }}/{{ export.total_sirets }} SIRETs terminés)</small>
+                    {% endif %}
+                {% else %}
+                    {{ export.identifier }}
+                {% endif %}
+            </td>
+            <td>
+                {{ export.registry_type_display }}
+                {% if export.type == 'SIREN' %}
+                    <br><span class="fr-badge fr-badge--sm fr-badge--info">SIREN</span>
+                {% endif %}
+            </td>
+            <td>{{ export.declaration_type_display }}</td>
             <td>{{ export.start_date|date:"SHORT_DATE_FORMAT" }}
                 <br> {{ export.end_date|date:"SHORT_DATE_FORMAT" }}</td>
 
             <td>
-
-                {% if export.in_progress %}
-                        <span class="fr-icon-refresh-line spinning fr-mx-1w"  ></span>
-            {% endif %}
-                {% if export.successful %}
-                    <form action="{% url "registry_v2_retrieve" export.pk %}" method="post">
+                {% if export.state == 'STARTED' or export.state == 'PENDING' %}
+                    <span class="fr-icon-refresh-line spinning fr-mx-1w"></span>
+                {% endif %}
+                {% if export.state == 'SUCCESSFUL' %}
+                    <form action="{% url "registry_v2_retrieve" export.id %}" method="post">
                         {% csrf_token %}
                         <button class="fr-btn fr-btn--tertiary fr-icon-download-line">download</button>
                     </form>

--- a/src/templates/registry/registry_v2_prepare.html
+++ b/src/templates/registry/registry_v2_prepare.html
@@ -15,8 +15,6 @@
     </div>
     <div class="fr-grid-row fr-grid-row--gutters">
     <div class="fr-col-4">
-
-
         <form method="post"
               action="{% url "registry_v2_prepare" %}"
               id="id_registry_prepare_form">
@@ -35,10 +33,10 @@
                 <div class="fr-col">{% include 'forms/_radio.html' with field=form.identifier_type %}</div>
             </div>
             <div class="fr-grid-row fr-grid-row--gutters" id="siret-field-container">
-                <div class="fr-col">{% include 'forms/_field.html' with field=form.siret %}</div>
+                <div class="fr-col">{% include 'forms/_field.html' with field=form.siret skip_optional=True %}</div>
             </div>
             <div class="fr-grid-row fr-grid-row--gutters" id="siren-field-container" style="display: none;">
-                <div class="fr-col">{% include 'forms/_field.html' with field=form.siren %}</div>
+                <div class="fr-col">{% include 'forms/_field.html' with field=form.siren skip_optional=True %}</div>
             </div>
             <div class="fr-grid-row fr-grid-row--gutters">
                 <div class="fr-col">{% include 'forms/_field.html' with field=form.registry_type %}</div>

--- a/src/templates/registry/registry_v2_prepare.html
+++ b/src/templates/registry/registry_v2_prepare.html
@@ -18,7 +18,7 @@
 
 
         <form method="post"
-                {% url "registry_v2_prepare" %}
+              action="{% url "registry_v2_prepare" %}"
               id="id_registry_prepare_form">
             {% csrf_token %}
             {% if form.errors or has_errors %}
@@ -32,7 +32,13 @@
                 </div>
             {% endif %}
             <div class="fr-grid-row fr-grid-row--gutters">
+                <div class="fr-col">{% include 'forms/_radio.html' with field=form.identifier_type %}</div>
+            </div>
+            <div class="fr-grid-row fr-grid-row--gutters" id="siret-field-container">
                 <div class="fr-col">{% include 'forms/_field.html' with field=form.siret %}</div>
+            </div>
+            <div class="fr-grid-row fr-grid-row--gutters" id="siren-field-container" style="display: none;">
+                <div class="fr-col">{% include 'forms/_field.html' with field=form.siren %}</div>
             </div>
             <div class="fr-grid-row fr-grid-row--gutters">
                 <div class="fr-col">{% include 'forms/_field.html' with field=form.registry_type %}</div>
@@ -132,5 +138,41 @@
             noChoicesText: 'Pas de résultat',
             itemSelectText: 'Cliquer pour sélectionner'
         })
+    </script>
+    <script>
+        // Conditional field display for identifier_type
+        document.addEventListener('DOMContentLoaded', function() {
+            const identifierTypeRadios = document.querySelectorAll('[name="identifier_type"]');
+            const siretContainer = document.getElementById('siret-field-container');
+            const sirenContainer = document.getElementById('siren-field-container');
+            const siretInput = document.querySelector('[name="siret"]');
+            const sirenInput = document.querySelector('[name="siren"]');
+            
+            function toggleFields() {
+                const selectedValue = document.querySelector('[name="identifier_type"]:checked')?.value;
+                
+                if (selectedValue === 'SIRET') {
+                    siretContainer.style.display = 'block';
+                    sirenContainer.style.display = 'none';
+                    if (sirenInput) {
+                        sirenInput.value = '';
+                    }
+                } else if (selectedValue === 'SIREN') {
+                    siretContainer.style.display = 'none';
+                    sirenContainer.style.display = 'block';
+                    if (siretInput) {
+                        siretInput.value = '';
+                    }
+                }
+            }
+            
+            // Add event listeners to all radio buttons
+            identifierTypeRadios.forEach(function(radio) {
+                radio.addEventListener('change', toggleFields);
+            });
+            
+            // Initial state
+            toggleFields();
+        });
     </script>
 {% endblock scripts %}


### PR DESCRIPTION
<!--
  Décrivez brièvement l'objectif de votre pull request.
  La liste ci-dessous comporte des éléments importants à garder en tête pour chaque PR.
  Pensez à ajouter le lien du ticket Favro correspondant.
-->
- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-XXXXX)

## Objectif
Permettre la génération et le téléchargement d’exports registre V2 **par SIREN** (tous les établissements), en conservant le flux existant **par SIRET**.

## Changements principaux
- **Exports SIREN/SIRET (nouveaux modèles + migration)**: ajout de `RegistryV2ExportSiren` (parent) et `RegistryV2ExportSiret` (enfants) + migration `0006_...`.
- **Préparation d’export**: `RegistryV2PrepareForm` supporte un choix `identifier_type` (radio) + champs conditionnels `siret` / `siren`, validation associée et création des exports enfants via récupération des SIRETs liés au SIREN (ClickHouse).
- **Traitement async**: `process_export()` orchestre désormais les exports SIRET existants + les exports SIREN (1 job par SIRET enfant) et met à jour l’état agrégé du parent.
- **API Trackdéchets**: mutation GraphQL utilisée côté génération passe sur `generateRegistryV2ExportAsAdmin` + durcissement de la gestion d’erreurs/retry (HTTP/GraphQL) avec bascule en `FAILED` au dépassement de retries.
- **Téléchargement SIREN**: l’endpoint de download renvoie un **ZIP** (1 fichier par SIRET exporté), avec téléchargement concurrent et tolérance aux échecs partiels.
- **UI**: la liste combine exports SIRET + SIREN (tri par `created_at`), badges/affichages adaptés; formulaire “prepare” met en avant le choix SIRET/SIREN.

## Fichiers impactés (high level)
- **Models/Migrations**: `src/registry/models.py`, `src/registry/migrations/0006_*.py`
- **Form/Views/Templates**: `src/registry/forms.py`, `src/registry/views.py`, `src/templates/registry/registry_v2_prepare.html`, `src/templates/registry/fragments/_registry_v2_list_content.html`
- **Async/GraphQL**: `src/registry/task.py`, `src/registry/gql.py`
- **Datawarehouse**: `src/sheets/queries.py`
- **Tests**: `src/registry/tests/test_tasks.py`, `src/registry/tests/test_views.py`
- **Admin/Factories/Constants**: `src/registry/admin.py`, `src/registry/factories.py`, `src/registry/constants.py`

## Points d’attention / risques
- **Volumétrie SIREN**: création de N exports enfants + N traitements async (un par SIRET) → charge potentielle élevée.
- **Download ZIP**: ZIP construit en mémoire et downloads réalisés dans le thread de requête (ThreadPool) → peut impacter latence/mémoire pour de gros SIREN.
- **Droits TD**: la mutation admin (`generateRegistryV2ExportAsAdmin`) dépend du token/permissions côté Trackdéchets.

## Plan de test
- [x] Lancer la migration: `uv run python src/manage.py migrate`
- [x] Cas SIRET: créer un export SIRET, vérifier état et téléchargement (URL signée).
- [x] Cas SIREN: créer un export SIREN, vérifier création des enfants, progression et état agrégé du parent.
- [x] Download SIREN: vérifier ZIP (1 fichier par SIRET terminé), et comportement si aucun export n’est disponible.
- [x] Exécuter les tests registry: `uv run pytest src/registry/tests/test_tasks.py src/registry/tests/test_views.py`


⚠️  Avant de merge : drop le commit `785e2b0 [tmp] use admin mutation` nécessaire pour tester en local