### PR TITLE
Corrections date exports pour absence des déclarations du 31/12/2025

### DIFF
--- a/src/registry/forms.py
+++ b/src/registry/forms.py
@@ -237,6 +237,7 @@ class RegistryV2PrepareForm(forms.ModelForm):
             export.siret = self.cleaned_data.get("siret")
             export.created_by = self.created_by
             export.created_by_email = self.created_by.email
+            export.end_date = export.end_date.replace(hour=23, minute=59, second=59)
             if commit:
                 export.save()
             return export


### PR DESCRIPTION
Problème de date entre la date envoyé par la vue utilisateur et celle envoyé à l'API trackdéchet.
La date utilisateur est réglé sur la timezone Europe/Paris, alors que Django utilise par défaut la timezone UTC.


- [TRA-18431](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-18431)
